### PR TITLE
remove 4000 characters input limit for automatically loaded datasets,

### DIFF
--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.ts
@@ -15,7 +15,7 @@ export class ManualProjectInputComponent implements OnChanges {
   form = new UntypedFormGroup({
     id: new UntypedFormControl(null),
     title: new UntypedFormControl('', [Validators.required, Validators.maxLength(255)]),
-    description: new UntypedFormControl('', [Validators.maxLength(4000)]),
+    description: new UntypedFormControl(''),
     start: new UntypedFormControl(null),
     end: new UntypedFormControl(null)
   })

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -368,7 +368,7 @@ export class FormService {
       startDate: [null],
       type: [[]],
       size: [null],
-      description: ['', Validators.maxLength(this.TEXT_MAX_LENGTH)],
+      description: [''],
       personalData: [false],
       sensitiveData: [false],
       legalRestrictions: [false],


### PR DESCRIPTION

to be used in pendant with GH-67
will remove validation limit for dataset description for automatically parsed datasets. still persists for manually typed descriptions.

closes GH-57
