### PR TITLE
Cached person list is confusing with multiple services available

### DIFF
--- a/libs/damap/src/lib/components/dmp/people/people.component.html
+++ b/libs/damap/src/lib/components/dmp/people/people.component.html
@@ -58,7 +58,7 @@
   <div>
     <mat-form-field appearance="fill">
       <mat-label>{{ 'dmp.steps.people.search.service' | translate }}</mat-label>
-      <mat-select [(value)]="serviceConfigType">
+      <mat-select [(value)]="serviceConfigType" (selectionChange)="onServiceConfigChange($event.value)">
         <mat-option *ngFor="let service of serviceConfig$ | keyvalue" [value]="service.value">
           {{  service.value.displayText | translate }}
         </mat-option>

--- a/libs/damap/src/lib/components/dmp/people/people.component.html
+++ b/libs/damap/src/lib/components/dmp/people/people.component.html
@@ -58,7 +58,7 @@
   <div>
     <mat-form-field appearance="fill">
       <mat-label>{{ 'dmp.steps.people.search.service' | translate }}</mat-label>
-      <mat-select [(value)]="serviceConfigType" (selectionChange)="onServiceConfigChange($event.value)">
+      <mat-select id="serviceSelect" [(value)]="serviceConfigType" (selectionChange)="onServiceConfigChange($event.value)">
         <mat-option *ngFor="let service of serviceConfig$ | keyvalue" [value]="service.value">
           {{  service.value.displayText | translate }}
         </mat-option>

--- a/libs/damap/src/lib/components/dmp/people/people.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.spec.ts
@@ -1,30 +1,60 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {ReactiveFormsModule, UntypedFormArray, UntypedFormControl, UntypedFormGroup} from '@angular/forms';
-import {mockContact, mockContributor1} from '../../../mocks/contributor-mocks';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ReactiveFormsModule,
+  UntypedFormArray,
+  UntypedFormControl,
+  UntypedFormGroup
+} from '@angular/forms';
+import {
+  configMockData,
+  serviceConfigMockData
+} from '../../../mocks/config-service-mocks';
+import {
+  mockContact,
+  mockContributor1
+} from '../../../mocks/contributor-mocks';
 
-import {BackendService} from '../../../services/backend.service';
-import {ContributorFilterPipe} from './contributor-filter.pipe';
-import {MatCardModule} from '@angular/material/card';
-import {MatDialogModule} from '@angular/material/dialog';
-import {MatIconModule} from '@angular/material/icon';
-import {MatSelectModule} from '@angular/material/select';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {PeopleComponent} from './people.component';
-import {TranslateTestingModule} from '../../../testing/translate-testing/translate-testing.module';
+import { BackendService } from '../../../services/backend.service';
+import { ContributorFilterPipe } from './contributor-filter.pipe';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { PeopleComponent } from './people.component';
+import { TranslateTestingModule } from '../../../testing/translate-testing/translate-testing.module';
+import { mockContributorSearchResult } from '../../../mocks/search';
 import { of } from 'rxjs';
 
 describe('PeopleComponent', () => {
   let component: PeopleComponent;
   let fixture: ComponentFixture<PeopleComponent>;
   let backendSpy;
+  let loadServiceConfigSpy;
 
   beforeEach(async () => {
-    backendSpy = jasmine.createSpyObj('BackendService', ['loadServiceConfig']);
-    backendSpy.loadServiceConfig.and.returnValue(of({}));
+    backendSpy = jasmine.createSpyObj('BackendService', [
+      'loadServiceConfig',
+      'getPersonSearchResult',
+    ]);
+    loadServiceConfigSpy = backendSpy.loadServiceConfig.and.returnValue(
+      of(configMockData)
+    );
+    backendSpy.getPersonSearchResult.and.returnValue(
+      of(mockContributorSearchResult)
+    );
     await TestBed.configureTestingModule({
-      imports: [TranslateTestingModule, MatCardModule, MatIconModule, MatDialogModule, ReactiveFormsModule, MatSelectModule, NoopAnimationsModule],
+      imports: [
+        TranslateTestingModule,
+        MatCardModule,
+        MatIconModule,
+        MatDialogModule,
+        ReactiveFormsModule,
+        MatSelectModule,
+        NoopAnimationsModule,
+      ],
       declarations: [PeopleComponent, ContributorFilterPipe],
-      providers: [{provide: BackendService, useValue: backendSpy}]
+      providers: [{ provide: BackendService, useValue: backendSpy }],
     }).compileComponents();
   });
 
@@ -46,6 +76,15 @@ describe('PeopleComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('ngOnInit', () => {
+    it('should load service config and set serviceConfigType to the first one', () => {
+      component.ngOnInit();
+
+      expect(loadServiceConfigSpy).toHaveBeenCalled();
+      expect(component.serviceConfig$).toEqual(serviceConfigMockData);
+      expect(component.serviceConfigType).toEqual(serviceConfigMockData[0]);
+    });   
+  });
 
   it('should emit contact', () => {
     spyOn(component.contactPerson, 'emit');
@@ -58,7 +97,9 @@ describe('PeopleComponent', () => {
     spyOn(component.contributorToAdd, 'emit');
 
     component.addContributor(mockContributor1);
-    expect(component.contributorToAdd.emit).toHaveBeenCalledOnceWith(mockContributor1);
+    expect(component.contributorToAdd.emit).toHaveBeenCalledOnceWith(
+      mockContributor1
+    );
   });
 
   it('should remove contributor from dataset and emit change', () => {

--- a/libs/damap/src/lib/components/dmp/people/people.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.spec.ts
@@ -90,7 +90,7 @@ describe('PeopleComponent', () => {
       expect(component.serviceConfigType).toEqual(serviceConfigMockData[0]);
     });
   });
-  
+
   it('should update serviceConfigType when a service option is selected', async () => {
     spyOn(component, 'onServiceConfigChange').and.callThrough();
 
@@ -114,14 +114,12 @@ describe('PeopleComponent', () => {
 
     expect(orcidOption).toBeTruthy();
 
-    if (orcidOption) {
-      await orcidOption.click();
-      fixture.detectChanges();
-    }
+    await orcidOption.click();
+    fixture.detectChanges();
 
     expect(component.serviceConfigType).toEqual(serviceConfigMockData[1]);
   });
-  
+
   it('should emit contact', () => {
     spyOn(component.contactPerson, 'emit');
 

--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -11,7 +11,7 @@ import {
 import { UntypedFormArray, UntypedFormGroup } from '@angular/forms';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Observable, Subject, Subscription } from 'rxjs';
-import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { debounceTime } from 'rxjs/operators';
 import { ServiceConfig } from '../../../domain/config-services';
 import { SearchResult } from '../../../domain/search/search-result';
 import { Contributor } from '../../../domain/contributor';

--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -27,9 +27,11 @@ import { PersonSearchComponent } from '../../../widgets/person-search/person-sea
   styleUrls: ['./people.component.css'],
 })
 export class PeopleComponent implements OnInit, OnDestroy {
+  @ViewChild(PersonSearchComponent) personSearch: PersonSearchComponent;
+
   @Input() projectMembers: Contributor[];
   @Input() dmpForm: UntypedFormGroup;
-  @ViewChild(PersonSearchComponent) personSearch: PersonSearchComponent;
+
   @Output() contactPerson = new EventEmitter<any>();
   @Output() contributorToAdd = new EventEmitter<any>();
   @Output() contributorToRemove = new EventEmitter<any>();

--- a/libs/damap/src/lib/mocks/config-service-mocks.ts
+++ b/libs/damap/src/lib/mocks/config-service-mocks.ts
@@ -1,0 +1,19 @@
+import { Config } from "../domain/config";
+import { ServiceConfig } from "../domain/config-services";
+
+// Mock data for service config
+export const serviceConfigMockData: ServiceConfig[] = [ 
+    { displayText: 'UNIVERSITY', queryValue: 'UNIVERSITY' },
+    { displayText: 'ORCID', queryValue: 'ORCID' }
+  ];
+  
+  // Mock data for config
+  export const configMockData: Config = {
+    authUrl: '',
+    authClient: '',
+    authScope: '',
+    authUser: '',
+    env: '',
+    personSearchServiceConfigs: serviceConfigMockData
+  };
+  

--- a/libs/damap/src/lib/mocks/config-service-mocks.ts
+++ b/libs/damap/src/lib/mocks/config-service-mocks.ts
@@ -1,19 +1,18 @@
-import { Config } from "../domain/config";
-import { ServiceConfig } from "../domain/config-services";
+import { Config } from '../domain/config';
+import { ServiceConfig } from '../domain/config-services';
 
 // Mock data for service config
-export const serviceConfigMockData: ServiceConfig[] = [ 
-    { displayText: 'UNIVERSITY', queryValue: 'UNIVERSITY' },
-    { displayText: 'ORCID', queryValue: 'ORCID' }
-  ];
-  
-  // Mock data for config
-  export const configMockData: Config = {
-    authUrl: '',
-    authClient: '',
-    authScope: '',
-    authUser: '',
-    env: '',
-    personSearchServiceConfigs: serviceConfigMockData
-  };
-  
+export const serviceConfigMockData: ServiceConfig[] = [
+  { displayText: 'UNIVERSITY', queryValue: 'UNIVERSITY' },
+  { displayText: 'ORCID', queryValue: 'ORCID' },
+];
+
+// Mock data for config
+export const configMockData: Config = {
+  authUrl: '',
+  authClient: '',
+  authScope: '',
+  authUser: '',
+  env: '',
+  personSearchServiceConfigs: serviceConfigMockData,
+};

--- a/libs/damap/src/lib/mocks/search.ts
+++ b/libs/damap/src/lib/mocks/search.ts
@@ -1,8 +1,11 @@
-import { Project } from '../domain/project';
+import { mockProject, mockRecommendedProject } from './project-mocks';
+
+import { Contributor } from '../domain/contributor';
 import { Pagination } from '../domain/search/pagination';
+import { Project } from '../domain/project';
 import { Search } from '../domain/search/search';
 import { SearchResult } from '../domain/search/search-result';
-import { mockProject, mockRecommendedProject } from './project-mocks';
+import { mockContact } from './contributor-mocks';
 
 export const mockPagination: Pagination = {
   page: 1,
@@ -24,4 +27,9 @@ export const mockProjectSearchResult: SearchResult<Project> = {
 export const mockRecommendedProjectSearchResult: SearchResult<Project> = {
   items: [mockRecommendedProject],
   search: mockSearch,
+}
+
+export const mockContributorSearchResult: SearchResult<Contributor> = {
+  search: mockSearch,
+  items: [mockContact]
 };

--- a/libs/damap/src/lib/mocks/search.ts
+++ b/libs/damap/src/lib/mocks/search.ts
@@ -22,11 +22,11 @@ export const mockSearch: Search = {
 export const mockRecommendedProjectSearchResult: SearchResult<Project> = {
   items: [mockRecommendedProject],
   search: mockSearch,
-}
+};
 
 export const mockContributorSearchResult: SearchResult<Contributor> = {
   search: mockSearch,
-  items: [mockContact]
+  items: [mockContact],
 };
 
 export const mockProjectSearchResult: SearchResult<Project> = {

--- a/libs/damap/src/lib/mocks/search.ts
+++ b/libs/damap/src/lib/mocks/search.ts
@@ -19,11 +19,6 @@ export const mockSearch: Search = {
   query: '',
 };
 
-export const mockProjectSearchResult: SearchResult<Project> = {
-  items: [mockProject],
-  search: mockSearch,
-};
-
 export const mockRecommendedProjectSearchResult: SearchResult<Project> = {
   items: [mockRecommendedProject],
   search: mockSearch,
@@ -32,4 +27,9 @@ export const mockRecommendedProjectSearchResult: SearchResult<Project> = {
 export const mockContributorSearchResult: SearchResult<Contributor> = {
   search: mockSearch,
   items: [mockContact]
+};
+
+export const mockProjectSearchResult: SearchResult<Project> = {
+  items: [mockProject],
+  search: mockSearch,
 };

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.ts
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.ts
@@ -11,13 +11,14 @@ export class PersonSearchComponent {
   @Input() result: Contributor[];
   @Output() termToSearch = new EventEmitter<string>();
   @Output() personToAdd = new EventEmitter<Contributor>();
-
-  constructor() {}
+  
+  currentSearchTerm: string;
 
   search(term: string) {
     if (term.trim()) {
       this.termToSearch.emit(term);
     }
+    this.currentSearchTerm = term;
   }
 
   selectPerson(person: Contributor) {

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.ts
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.ts
@@ -1,20 +1,18 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
-import {Contributor} from '../../domain/contributor';
+import { Contributor } from '../../domain/contributor';
 
 @Component({
   selector: 'app-person-search',
   templateUrl: './person-search.component.html',
-  styleUrls: ['./person-search.component.css']
+  styleUrls: ['./person-search.component.css'],
 })
 export class PersonSearchComponent {
-
   @Input() result: Contributor[];
   @Output() termToSearch = new EventEmitter<string>();
   @Output() personToAdd = new EventEmitter<Contributor>();
 
-  constructor() {
-  }
+  constructor() {}
 
   search(term: string) {
     if (term.trim()) {
@@ -25,5 +23,4 @@ export class PersonSearchComponent {
   selectPerson(person: Contributor) {
     this.personToAdd.emit(person);
   }
-
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
The PR updates the PeopleComponent and PersonSearchComponent to address an issue where the search result was not being updated properly when the user changed the service type. To fix this issue, the searchResult$ Observable is passed as an Input to the PersonSearchComponent, and the result Input is removed. This allows the search result to be updated dynamically based on the user's input and service type.

#### Breaking changes
There are no breaking changes introduced in this PR.

#### Code review focus
The main focus of the code review should be on the changes made to the PeopleComponent and PersonSearchComponent. 
#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
- [x] Summary updated
- [ ] Version view updated
- [x] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
