### PR TITLE
component: fetch recommended projects on start and empty input

### DIFF
--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
@@ -12,7 +12,10 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BackendService } from '@damap/core';
 import { of } from 'rxjs';
 import { mockProject } from '../../../../mocks/project-mocks';
-import { mockProjectSearchResult } from '../../../../mocks/search';
+import {
+  mockProjectSearchResult,
+  mockRecommendedProjectSearchResult,
+} from '../../../../mocks/search';
 import { TranslateTestingModule } from '../../../../testing/translate-testing/translate-testing.module';
 import { ProjectListComponent } from './project-list.component';
 
@@ -20,13 +23,29 @@ describe('ProjectListComponent', () => {
   let component: ProjectListComponent;
   let fixture: ComponentFixture<ProjectListComponent>;
   let loader: HarnessLoader;
-  let backendSpy
+  let backendSpy;
+
   beforeEach(async () => {
-    backendSpy = jasmine.createSpyObj('BackendService', ['getProjectSearchResult']);
-    backendSpy.getProjectSearchResult.and.returnValue(of(mockProjectSearchResult));
+    backendSpy = jasmine.createSpyObj('BackendService', [
+      'getProjectSearchResult',
+      'getRecommendedProjects',
+    ]);
+    backendSpy.getProjectSearchResult.and.returnValue(
+      of(mockProjectSearchResult)
+    );
+    backendSpy.getRecommendedProjects.and.returnValue(
+      of(mockRecommendedProjectSearchResult)
+    );
 
     await TestBed.configureTestingModule({
-      imports: [TranslateTestingModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatListModule, NoopAnimationsModule],
+      imports: [
+        TranslateTestingModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatListModule,
+        NoopAnimationsModule,
+      ],
       declarations: [ProjectListComponent],
       providers: [{ provide: BackendService, useValue: backendSpy }],
     }).compileComponents();
@@ -39,6 +58,22 @@ describe('ProjectListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should fetch recommended projects after creation', async () => {
+    // making sure that the input is initialized
+    await loader.getHarness(MatInputHarness);
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
+  });
+
+  it('should load projects on text input', async () => {
+    const input = await loader.getHarness(MatInputHarness);
+
+    await input.setValue(mockProject.title);
+    expect(backendSpy.getProjectSearchResult).toHaveBeenCalled();
+
+    await input.setValue('');
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
   });
 
   it('should change project on selection', async () => {

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
@@ -1,10 +1,20 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSelectionListChange } from '@angular/material/list';
-import { BackendService } from "../../../../services/backend.service";
+import { BackendService } from '../../../../services/backend.service';
 import {
   debounceTime,
-  distinctUntilChanged, Observable, Subject, switchMap
+  distinctUntilChanged,
+  Observable,
+  Subject,
+  switchMap,
 } from 'rxjs';
 import { Project } from '../../../../domain/project';
 import { SearchResult } from '../../../../domain/search/search-result';
@@ -14,7 +24,7 @@ import { SearchResult } from '../../../../domain/search/search-result';
   templateUrl: './project-list.component.html',
   styleUrls: ['./project-list.component.css'],
 })
-export class ProjectListComponent implements OnInit {
+export class ProjectListComponent implements OnInit, AfterViewInit {
   @Input() selectedProject: Project;
   @Output() projectToSet = new EventEmitter<Project>();
 
@@ -31,9 +41,17 @@ export class ProjectListComponent implements OnInit {
       debounceTime(300),
       distinctUntilChanged(),
       switchMap((term: string) => {
-        return this.backendService.getProjectSearchResult(term);
+        if (term === null || term.length === 0) {
+          return this.backendService.getRecommendedProjects();
+        } else {
+          return this.backendService.getProjectSearchResult(term);
+        }
       })
     );
+  }
+
+  ngAfterViewInit(): void {
+    this.search(null);
   }
 
   search(term: string) {

--- a/libs/damap/src/lib/mocks/project-mocks.ts
+++ b/libs/damap/src/lib/mocks/project-mocks.ts
@@ -24,6 +24,28 @@ export const mockProject: Project = {
   dmpExists: true
 };
 
+export const mockRecommendedProject: Project = {
+  end: new Date(),
+  funding: {
+    fundingName: 'Funding name',
+    fundingProgram: 'Funding program',
+    funderId: {
+      identifier: '501100004955', type: IdentifierType.FUNDREF
+    },
+    fundingStatus: FundingState.GRANTED,
+    grantId: {
+      identifier: '1337',
+      type: null
+    }, id: 1337
+  },
+  id: 1337,
+  start: new Date(),
+  title: 'Recommended Project title',
+  universityId: 1337,
+  description: '',
+  dmpExists: true
+};
+
 export const mockManualProject: Project = {
   end: new Date(),
   funding: undefined,

--- a/libs/damap/src/lib/mocks/search.ts
+++ b/libs/damap/src/lib/mocks/search.ts
@@ -2,7 +2,7 @@ import { Project } from '../domain/project';
 import { Pagination } from '../domain/search/pagination';
 import { Search } from '../domain/search/search';
 import { SearchResult } from '../domain/search/search-result';
-import { mockProject } from './project-mocks';
+import { mockProject, mockRecommendedProject } from './project-mocks';
 
 export const mockPagination: Pagination = {
   page: 1,
@@ -18,5 +18,10 @@ export const mockSearch: Search = {
 
 export const mockProjectSearchResult: SearchResult<Project> = {
   items: [mockProject],
+  search: mockSearch,
+};
+
+export const mockRecommendedProjectSearchResult: SearchResult<Project> = {
+  items: [mockRecommendedProject],
   search: mockSearch,
 };

--- a/libs/damap/src/lib/services/backend.service.ts
+++ b/libs/damap/src/lib/services/backend.service.ts
@@ -152,6 +152,16 @@ export class BackendService {
     );
   }
 
+  getRecommendedProjects(): Observable<SearchResult<Project>> {
+    return this.http
+      .get<SearchResult<Project>>(`${this.projectBackendUrl}/recommended`)
+      .pipe(
+        retry(3),
+        catchError(this.handleError('http.error.projects')),
+        shareReplay(1)
+      );
+  }
+
   getProjectSearchResult(searchTerm: string): Observable<SearchResult<Project>> {
     let queryParams = new HttpParams({
       fromObject: {


### PR DESCRIPTION
tests: add test cases for fetching projects

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Feature 

#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
This will fetch recommended projects when loading the project component. Recommended projects will also be fetched when the search input is empty.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->
depends on backend issue: https://github.com/tuwien-csd/damap-backend/pull/86

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-103
