### PR TITLE
Fix export functionality for items without funding and dropdown feature

### DIFF
--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   DmpActionsComponent,
-  SaveVersionDialogComponent
+  SaveVersionDialogComponent,
 } from './dmp-actions.component';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Subject, of } from 'rxjs';
@@ -142,7 +142,10 @@ describe('DmpActionsComponent', () => {
 
     component.exportDmpTemplate();
 
-    expect(component.exportDmpTemplate).toHaveBeenCalledTimes(1);
-    expect(component.dispatchExportDmp).toHaveBeenCalledTimes(1);
+    await fixture.whenStable();
+
+    expect(component.dispatchExportDmp).not.toHaveBeenCalled();
+    expect((component as any).dialog.open).toHaveBeenCalled();
+    expect(component.dmpForm.controls.project.getRawValue).toHaveBeenCalled();
   });
 });

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
@@ -103,16 +103,20 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
     dialogRef.beforeClosed().subscribe(result => {
       if (result === undefined) {
         return;
-      }
-      if (!this.dmpForm.controls.project.getRawValue().funderSupported) {
+      } else {
         const template = result;
-        this.exportDmpType = template;
-        exportDmpTemplate({
-          dmp: this.formService.exportFormToDmp(),
-          dmpTemplateType: this.exportDmpType,
-        });
+        if (!this.dmpForm.controls.project.getRawValue().funderSupported) {
+          this.exportDmpType = template;
+          this.store.dispatch(
+            exportDmpTemplate({
+              dmp: this.formService.exportFormToDmp(),
+              dmpTemplateType: this.exportDmpType,
+            })
+          );
+        } else {
+          this.dispatchExportDmp();
+        }
       }
-      this.dispatchExportDmp();
     });
   }
 }

--- a/libs/damap/src/lib/components/plans/plans.component.spec.ts
+++ b/libs/damap/src/lib/components/plans/plans.component.spec.ts
@@ -137,6 +137,5 @@ describe('PlanComponent', () => {
       id,
       'some_template'
     );
-    expect(backendSpy.getDmpDocument).toHaveBeenCalledWith(id);
   }));
 });

--- a/libs/damap/src/lib/components/plans/plans.component.ts
+++ b/libs/damap/src/lib/components/plans/plans.component.ts
@@ -69,13 +69,16 @@ export class PlansComponent implements OnInit {
     dialogRef.componentInstance.funderSupported = funderSupported;
 
     dialogRef.beforeClosed().subscribe(result => {
-      if (result === undefined) {return;} else {
+      if (result === undefined) {
+        return;
+      } else {
         if (!funderSupported) {
           const template = result;
           this.exportDmpType = template;
           this.backendService.exportDmpTemplate(id, this.exportDmpType);
+        } else {
+          this.backendService.getDmpDocument(id);
         }
-        this.backendService.getDmpDocument(id);
       }
     });
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description - Bugfix
This PR fixes a bug with the dropdown feature for exporting documents. Previously, exporting items without funding would call the base export function instead of the chosen template function. Additionally, exporting from the overview list would call both the basic function and the chosen template function, resulting in two downloads.

#### What does this PR do?
This PR ensures that the chosen template function is called when exporting items without funding and only one download is prompted when exporting from the overview list.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
