### PR TITLE
User Interface Improvements for Storage Selection and Dataset Access Rights

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -124,7 +124,7 @@
           }
         },
         "access": {
-          "heading": "Set access rights for all datasets",
+          "heading": "Planned access rights for all datasets",
           "question": {
             "dataset": "Dataset",
             "selected": "for selected project members",

--- a/libs/damap/src/lib/components/dmp/data-storage/data-access/data-access.component.css
+++ b/libs/damap/src/lib/components/dmp/data-storage/data-access/data-access.component.css
@@ -23,3 +23,11 @@
 .bold {
   font-weight: bold;
 }
+
+.mat-expansion-panel {
+  background: #006699;
+}
+
+.mat-panel-title {
+  color: white;
+}

--- a/libs/damap/src/lib/components/dmp/data-storage/data-access/data-access.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/data-access/data-access.component.html
@@ -1,8 +1,8 @@
 <mat-accordion>
-  <mat-expansion-panel (opened)="panelOpenState = true"
+  <mat-expansion-panel class="mat-panel" (opened)="panelOpenState = true"
                        (closed)="panelOpenState = false">
     <mat-expansion-panel-header>
-      <mat-panel-title>
+      <mat-panel-title class="mat-panel-title">
         {{'dmp.steps.data.access.heading' | translate}}
       </mat-panel-title>
     </mat-expansion-panel-header>

--- a/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.css
+++ b/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.css
@@ -1,0 +1,22 @@
+.tu-storage {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.storage-selected {
+  flex-grow: 100;
+}
+
+.storage-card-top {
+  display: flex;
+  flex-grow: 100;
+  justify-content: space-between;
+}
+
+.storage-grid {
+  min-width: 300px;
+  width: 30%;
+  max-height: 400px;
+  overflow-y: scroll;
+}

--- a/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
@@ -1,54 +1,60 @@
-<button mat-stroked-button (click)="addExternalStorage()" [style]="'margin: 5px;'">
-  {{'dmp.steps.storage.external.add' | translate}}
-</button>
-<section class="external-storage">
-  <mat-accordion>
-    <mat-expansion-panel *ngFor="let item of externalStorageStep?.controls; let i = index">
-      <mat-expansion-panel-header>
-        <mat-panel-title [class.form-error]="item.invalid">
-          {{item.value.title}}
-        </mat-panel-title>
-        <mat-panel-description>
-          {{item.value.backupLocation}}
-        </mat-panel-description>
-      </mat-expansion-panel-header>
-      <div class="form-row">
-        <div class="form-row-group">
-          <app-input-wrapper [label]="'dmp.steps.storage.external.question.name'"
-                             [control]="getFormControl(i, 'title')"></app-input-wrapper>
-          <button mat-icon-button color="accent" aria-label="{{'dmp.steps.storage.external.remove' | translate}}"
-                  (click)="removeExternalStorage(i)">
-            <mat-icon>cancel</mat-icon>
-          </button>
+<section class="tu-storage">
+  <div class="storage-grid">
+    <button mat-raised-button color="primary" (click)="addExternalStorage()" [style]="'margin: 5px; font-weight: normal'">
+      {{'dmp.steps.storage.external.add' | translate}}
+    </button>
+  </div>
+  <div class="storage-selected">
+    <ng-container>
+      <mat-card *ngFor="let item of externalStorageStep?.controls; let i = index">
+        <div class="storage-card-top">
+          <mat-card-title [class.form-error]="item.invalid">
+            {{item.value.title}}
+          </mat-card-title>
+          <mat-panel-description>
+            {{item.value.backupLocation}}
+          </mat-panel-description>
         </div>
-      </div>
-      <div class="form-row">
-        <div class="form-row-group">
-          <mat-form-field class="full-width">
-            <mat-label>{{'dmp.steps.storage.question.datasets' | translate}}</mat-label>
-            <mat-select multiple [formControl]="getFormControl(i, 'datasets')">
-              <mat-option *ngFor="let dataset of datasets?.controls" [value]="dataset.value.referenceHash">
-                {{dataset.value.title}}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-          <app-input-wrapper [label]="'dmp.steps.storage.external.question.location'"
-                             [control]="getFormControl(i, 'storageLocation')"></app-input-wrapper>
-        </div>
-      </div>
-      <div class="form-row">
-        <div class="form-row-group">
-          <app-input-wrapper [label]="'dmp.steps.storage.external.question.backup.frequency'"
-                             [control]="getFormControl(i, 'backupFrequency')"></app-input-wrapper>
-          <app-input-wrapper [label]="'dmp.steps.storage.external.question.backup.location'"
-                             [control]="getFormControl(i, 'backupLocation')"></app-input-wrapper>
-        </div>
-      </div>
-    </mat-expansion-panel>
-  </mat-accordion>
-  <div *ngIf="externalStorageStep?.controls.length" class="storage-textarea" [style]="'margin: 5px;'">
-    <app-textarea-wrapper [label]="'dmp.steps.storage.external.question.info'"
-                          [control]="externalStorageInfo" [appearance]="'fill'">
-    </app-textarea-wrapper>
+        <mat-card-content>
+          <div class="form-row">
+            <div class="storage-card-top">
+              <app-input-wrapper [label]="'dmp.steps.storage.external.question.name'"
+                [control]="getFormControl(i, 'title')"></app-input-wrapper>
+              <button mat-icon-button color="primary" aria-label="{{'dmp.steps.storage.external.remove' | translate}}"
+                (click)="removeExternalStorage(i)">
+                <mat-icon>cancel</mat-icon>
+              </button>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="storage-card-top">
+              <mat-form-field class="full-width">
+                <mat-label>{{'dmp.steps.storage.question.datasets' | translate}}</mat-label>
+                <mat-select multiple [formControl]="getFormControl(i, 'datasets')">
+                  <mat-option *ngFor="let dataset of datasets?.controls" [value]="dataset.value.referenceHash">
+                    {{dataset.value.title}}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+              <app-input-wrapper [label]="'dmp.steps.storage.external.question.location'"
+                [control]="getFormControl(i, 'storageLocation')"></app-input-wrapper>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="storage-card-top">
+              <app-input-wrapper [label]="'dmp.steps.storage.external.question.backup.frequency'"
+                [control]="getFormControl(i, 'backupFrequency')"></app-input-wrapper>
+              <app-input-wrapper [label]="'dmp.steps.storage.external.question.backup.location'"
+                [control]="getFormControl(i, 'backupLocation')"></app-input-wrapper>
+            </div>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </ng-container>
+    <div *ngIf="externalStorageStep?.controls.length" class="storage-textarea" [style]="'margin: 5px;'">
+      <app-textarea-wrapper [label]="'dmp.steps.storage.external.question.info'" [control]="externalStorageInfo"
+        [appearance]="'fill'">
+      </app-textarea-wrapper>
+    </div>
   </div>
 </section>

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
@@ -21,7 +21,7 @@
         <div class="storage-card-top">
           <mat-card-title>{{item.value.title}}</mat-card-title>
           <mat-card-actions>
-            <button mat-icon-button color="accent" aria-label="{{'dmp.steps.storage.remove' | translate}}"
+            <button mat-icon-button color="primary" aria-label="{{'dmp.steps.storage.remove' | translate}}"
                     (click)="removeStorage(i)">
               <mat-icon>cancel</mat-icon>
             </button>

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
@@ -1,13 +1,14 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Store, select} from '@ngrx/store';
 import {UntypedFormArray, UntypedFormGroup} from '@angular/forms';
-import {InternalStorage} from '../../../../domain/internal-storage';
-import {select, Store} from '@ngrx/store';
-import {AppState} from '../../../../store/states/app.state';
-import {LoadingState} from '../../../../domain/enum/loading-state.enum';
 import {
   selectInternalStorages,
   selectInternalStoragesLoaded
 } from '../../../../store/selectors/internal-storage.selectors';
+
+import {AppState} from '../../../../store/states/app.state';
+import {InternalStorage} from '../../../../domain/internal-storage';
+import {LoadingState} from '../../../../domain/enum/loading-state.enum';
 import {loadInternalStorages} from '../../../../store/actions/internal-storage.actions';
 
 @Component({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
This PR addresses three user interface issues related to storage selection and dataset access rights.

#### What does this PR do?
Integrates the "Other Storages" list into the selected storages list located on the right-hand side. The "Add Storage" button remains beneath the left-hand list of storage options and its visibility is enhanced by color-coding it according to our CI guidelines. Clicking this button will add a new item to the selected storages list on the right, which will include the editable metadata item previously added below, and allow dataset assignment.

Update the text to read “Planned access rights for all datasets”.

Enhance the visibility of the "Set access rights for all datasets" dropdown list. This could be achieved by changing the item's color to something more distinct and noticeable.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
