### PR TITLE
Change template dropdown names to be more easy to read

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -819,7 +819,7 @@
     },
     "exportDmpTemplatetype": {
       "FWF": "FWF",
-      "SCIENCE_EUROPE":"SCIENCE_EUROPE"
+      "SCIENCE_EUROPE": "Science Europe"
     }
   },
   "yes": "Yes",

--- a/libs/damap/src/lib/domain/enum/export-template-type.enum.ts
+++ b/libs/damap/src/lib/domain/enum/export-template-type.enum.ts
@@ -1,4 +1,4 @@
 export enum ETemplateType {
   FWF = 'FWF',
-  SCIENCE_EUROPE = 'SCIENCE_EUROPE',
+  SCIENCE_EUROPE = 'Science Europe',
 }

--- a/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.component.ts
+++ b/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.component.ts
@@ -15,6 +15,8 @@ export class ExportWarningDialogComponent {
   @Input() funderSupported: boolean;
 
   dmpTemplate: any = ETemplateType;
+
+  translateTemplatePrefixEnum = 'enum.exportDmpTemplatetype.'
   selectedTemplate = '';
 
   constructor(public dialogRef: MatDialogRef<ExportWarningDialogComponent>) {}

--- a/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.component.ts
+++ b/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.component.ts
@@ -16,7 +16,6 @@ export class ExportWarningDialogComponent {
 
   dmpTemplate: any = ETemplateType;
 
-  translateTemplatePrefixEnum = 'enum.exportDmpTemplatetype.'
   selectedTemplate = '';
 
   constructor(public dialogRef: MatDialogRef<ExportWarningDialogComponent>) {}

--- a/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.html
+++ b/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.html
@@ -10,7 +10,7 @@
             <mat-option
               *ngFor="let id of dmpTemplate | keyvalue"
               [value]="id.key">
-              {{translateTemplatePrefixEnum + id.key | translate}}<br />
+              {{id.value | translate}}<br />
             </mat-option>
           </mat-select>
         </mat-form-field>

--- a/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.html
+++ b/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.html
@@ -10,7 +10,7 @@
             <mat-option
               *ngFor="let id of dmpTemplate | keyvalue"
               [value]="id.key">
-              {{id.key}}<br />
+              {{translateTemplatePrefixEnum + id.key | translate}}<br />
             </mat-option>
           </mat-select>
         </mat-form-field>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
This PR introduces an improvement to the user interface of the template selection dropdown for exports.

#### What does this PR do?
Currently, the template dropdown for choosing the template to export into lists the enum names as a String property. To improve readability and clarity, this PR updates the enum display names as follows:

    FWF: No change, stays as "FWF"
    SCIENCE_EUROPE: Changes to "Science Europe"

This change should make it easier for users to identify and select the correct export template.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
