### PR TITLE
Retention period element in repositories section is easily overlooked

### DIFF
--- a/libs/damap/src/lib/components/dmp/repo/retention-period/retention-period.component.css
+++ b/libs/damap/src/lib/components/dmp/repo/retention-period/retention-period.component.css
@@ -1,0 +1,9 @@
+.mat-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .color-icon{
+    color: #006699
+  }

--- a/libs/damap/src/lib/components/dmp/repo/retention-period/retention-period.component.html
+++ b/libs/damap/src/lib/components/dmp/repo/retention-period/retention-period.component.html
@@ -1,10 +1,11 @@
-<div [formGroup]="dmpForm">
+<div class="mat-panel" [formGroup]="dmpForm">
   <mat-accordion>
     <mat-expansion-panel hideToggle>
-      <mat-expansion-panel-header>
+      <mat-expansion-panel-header >
         <mat-panel-title>
           {{'dmp.steps.retentionPeriod.title' | translate}}
         </mat-panel-title>
+        <mat-icon class="color-icon">edit_calendar</mat-icon>
       </mat-expansion-panel-header>
       <ng-container *ngFor="let dataset of datasets.controls, index as i">
         <ng-container *ngIf="dataset.value.source === datasetSource.NEW">


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
The section in my view is now more visible with an icon added and placed to the right. 
Previous: 
![image](https://github.com/tuwien-csd/damap-frontend/assets/112856634/ea83cf1e-32f9-4e7d-8c19-24a8c6c21b27)
<img width="746" alt="version1" src="https://github.com/tuwien-csd/damap-frontend/assets/112856634/0200624d-7a82-467d-8ad0-a34a47028cc5">


#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
Ideally the tool should be tested with a new user, in order to check improvements.

#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
