### PR TITLE
Show alert box when 'marked for deletion'

### DIFF
--- a/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.html
+++ b/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="dataset">
-  <div class="warning" *ngIf="willBePublished">
+  <div class="warning" *ngIf="dataset.value.delete">
     <div class="warning-icon">
       <mat-icon>error_outline</mat-icon>
     </div>
@@ -28,7 +28,7 @@
         <mat-label>{{
           'dmp.steps.data.deletion.question.date' | translate
           }}</mat-label>
-        <input matInput formControlName="dateOfDeletion" [matDatepicker]="picker"  />
+        <input matInput formControlName="dateOfDeletion" [matDatepicker]="picker" />
         <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
         <mat-datepicker #picker></mat-datepicker>
       </mat-form-field>
@@ -37,5 +37,4 @@
       [maxLength]="4000">
     </app-input-wrapper>
   </div>
-  
 </div>

--- a/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.spec.ts
@@ -1,10 +1,10 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {UntypedFormArray, UntypedFormControl, UntypedFormGroup} from '@angular/forms';
+import {mockContributor1, mockContributor2} from '../../../mocks/contributor-mocks';
 
 import {DataDeletionComponent} from './data-deletion.component';
-import {UntypedFormArray, UntypedFormControl, UntypedFormGroup} from '@angular/forms';
 import {MatSliderModule} from '@angular/material/slider';
 import {TranslateTestingModule} from '../../../testing/translate-testing/translate-testing.module';
-import {mockContributor1, mockContributor2} from '../../../mocks/contributor-mocks';
 
 describe('DataDeletionComponent', () => {
   let component: DataDeletionComponent;
@@ -41,26 +41,5 @@ describe('DataDeletionComponent', () => {
     expect(component.getSelection(mockContributor1, mockContributor1)).toBe(true);
     expect(component.getSelection(mockContributor1, null)).toBe(false);
     expect(component.getSelection(null, null)).toBe(true);
-  });
-
-  it('should check if dataset will be published', () => {
-    component.dmpForm = new UntypedFormGroup({
-      repositories: new UntypedFormArray([
-        new UntypedFormControl({datasets: ['ref1']}),
-        new UntypedFormControl({datasets: ['ref1']})
-      ])
-    });
-    component.dataset = new UntypedFormGroup({
-      referenceHash: new UntypedFormControl('ref1')
-    });
-
-    expect(component.willBePublished).toBe(true);
-
-
-    component.dataset = new UntypedFormGroup({
-      referenceHash: new UntypedFormControl('ref2')
-    });
-
-    expect(component.willBePublished).toBe(false);
   });
 });

--- a/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.ts
+++ b/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.ts
@@ -31,10 +31,4 @@ export class DataDeletionComponent {
   get reasonForDeletion(): UntypedFormControl {
     return this.dataset.controls.reasonForDeletion as UntypedFormControl;
   }
-
-  get willBePublished(): boolean {
-    return !!this.dmpForm.value.repositories.filter(item =>
-      item.datasets.includes(this.dataset.value.referenceHash)
-    ).length;
-  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->

The issue where the alert box was not being displayed upon checking the "Marked for deletion" checkbox has been resolved. Previously, when the "Marked for deletion" checkbox was checked, no alert box was displayed, which was contrary to the expected behavior

#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
