### PR TITLE
[Bugfix] without project the form throws an error

### DIFF
--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -112,7 +112,7 @@ export class FormService {
     this.form.patchValue({
       id: dmp.id,
       project: dmp.project,
-      funding: dmp.project.funding,
+      funding: dmp.project?.funding,
       data: {
         kind: dmp.dataKind,
         reusedKind: dmp.reusedDataKind,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix: Currently trying to save a DMP without a DMP connected to it, will cause the form to throw an error (trying to access project data with project null) and will cause the application to save an empty DMP. all subsequent save attempts will also create a new DMP , as the failure to load the DMP from the backend results in the ID also being empty. 

#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
This fix will only query the funding data if the project data is also available. Thus resolving the error triggered when loading the form without project.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->
No breaking changes.

#### Code review focus
<!-- What you want the reviewer to focus on -->
Please check if there are other similar potential breaking points, or if the change has any repercussions further in the workflow

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
