### PR TITLE
[hotfix] add nx version constraint to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY . /app
 ENV PATH="$PATH:/app/node_modules/@angular/cli/bin/"
 
 # install and build the application on the builder container
-RUN npm install -g nx && \
+RUN npm install -g "nx@<16.7.0" && \
     npm install
 RUN npx nx build damap-frontend
 


### PR DESCRIPTION
#### What does this PR do?
Constraints the nx version to <16.7.0 in the Dockerfile because the latest one is causing a build failure

closes GH-138