### PR TITLE
Vf/117 add a date input to license information to indicate dataset publication

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -248,7 +248,7 @@
         "question": {
           "dataAccess": "Data Access",
           "license": "Planned license",
-          "startDate": "Choose a date for publication",
+          "startDate": "Estimated publication date",
           "hint": "The release date was set to the project end date. Feel free to modify it.",
           "restrictedAccessInfo": "The following dataset(s) will have access restrictions, explain why and clearly describe the access conditions:",
           "closedAccessInfo": "Explain why the data will not be accessible (closed access):"

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -161,13 +161,9 @@ export class DmpComponent implements OnInit, OnDestroy {
     this.formService.removeContributorFromForm(index);
   }
 
-  createDataset(title: string) {
-    this.formService.addDatasetToForm(this.generateReferenceHash(), title);
-  }
-
   addDataset(dataset: Dataset) {
     dataset.referenceHash = this.generateReferenceHash();
-    this.formService.addReusedDatasetToForm(dataset);
+    this.formService.addDatasetToForm(dataset);
   }
 
   updateDataset(event: { index: number; update: Dataset }) {
@@ -192,7 +188,7 @@ export class DmpComponent implements OnInit, OnDestroy {
           const dataset = response.body;
           dataset.title = filename;
           dataset.referenceHash = reference;
-          this.formService.addFileAnalysisAsDatasetToForm(dataset);
+          this.formService.addDatasetToForm(dataset);
         }
       },
       error: _ => (upload.finalized = true),

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -77,7 +77,6 @@ export class DmpComponent implements OnInit, OnDestroy {
     this.getDmpById();
 
     this.dmpForm.valueChanges.subscribe(value => {
-      this.logger.debug('DMPform Update');
       this.logger.debug(value);
       this.store.dispatch(formDiff({ newDmp: value }));
     });
@@ -131,7 +130,6 @@ export class DmpComponent implements OnInit, OnDestroy {
       this.datasets.length
     );
   }
-
   changeStep($event) {
     this.stepChanged$.next($event);
   }
@@ -142,6 +140,9 @@ export class DmpComponent implements OnInit, OnDestroy {
         this.getProjectMembers(project.universityId);
       }
       this.projectStep.setValue(project);
+      if (project.end != null) {
+        this.formService.presetStartDateOnDatasets();
+      }
     } else {
       this.projectMembers.length = 0;
       this.projectStep.reset();

--- a/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
+++ b/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
@@ -69,6 +69,20 @@
           </div>
         </ng-container>
 
+        <div class="mat-card-container">
+          <mat-form-field>
+            <mat-label>{{
+              "dmp.steps.licensing.question.startDate" | translate
+              }}</mat-label>
+            <input
+              matInput
+              formControlName="startDate"
+              [matDatepicker]="picker">
+            <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+            <mat-datepicker #picker></mat-datepicker>
+          </mat-form-field>
+        </div>
+
         <ng-container *ngIf="dataset.value.dataAccess === accessType.CLOSED">
           <app-data-deletion
             [dataset]="getFormGroup(i)"

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -325,20 +325,8 @@ export class FormService {
     (this.form.get('contributors') as UntypedFormArray).removeAt(index);
   }
 
-  public addDatasetToForm(reference: string, title: string) {
-    const formGroup = this.createDatasetFormGroup(title);
-    formGroup.patchValue({
-      referenceHash: reference,
-      startDate: this.form.value.project?.end || null,
-      dateOfDeletion: this.form.value.project?.end || null,
-    });
-    (this.form.get('datasets') as UntypedFormArray).push(formGroup);
-  }
-
-  public addReusedDatasetToForm(dataset: Dataset) {
-    if (dataset.startDate == null) {
-      dataset.startDate = this.getStartDate();
-    }
+  public addDatasetToForm(dataset: Dataset) {
+    dataset.startDate = this.getStartDate();
 
     const formGroup = this.mapDatasetToFormGroup(dataset);
     (this.form.get('datasets') as UntypedFormArray).push(formGroup);
@@ -352,15 +340,6 @@ export class FormService {
   public removeDatasetFromForm(index: number) {
     this.removeDatasetReferences(index);
     (this.form.get('datasets') as UntypedFormArray).removeAt(index);
-  }
-
-  public addFileAnalysisAsDatasetToForm(dataset: Dataset) {
-    if (dataset.startDate == null) {
-      dataset.startDate = this.getStartDate();
-    }
-
-    const formGroup = this.mapDatasetToFormGroup(dataset);
-    (this.form.get('datasets') as UntypedFormArray).push(formGroup);
   }
 
   public addStorageToForm(storage: InternalStorage) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Feature/Refactoring

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->
License step now has a date input field for the estimated data publication date.
If the project has an end date, the publication date input of new datasets is prefilled to 2 months before project end.  If a project end date gets added or updated, old datasets are prefilled the same way but only if the publication date was null beforehand. This behaviour was specified by Christiane.

#### Code review focus

Did I break any Angular coding conventions?
Does the refactoring (second commit) make sense for you?

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
