### PR TITLE
version table: Replace revision number with editor name

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -588,7 +588,7 @@
     "versionId": "Version",
     "versionName": "Name",
     "versionDate": "Date",
-    "revisionNumber": "Revision",
+    "editor": "Editor",
     "list": {
       "no.data": "No versions available."
     },

--- a/libs/damap/src/lib/components/version/version-table/version-table.component.html
+++ b/libs/damap/src/lib/components/version/version-table/version-table.component.html
@@ -30,12 +30,12 @@
       </td>
     </ng-container>
 
-    <!-- Revision Column -->
-    <ng-container matColumnDef="revision">
+    <!-- Editor Column -->
+    <ng-container matColumnDef="editor">
       <th mat-header-cell *matHeaderCellDef>
-        {{ "versions.revisionNumber" | translate }}
+        {{ "versions.editor" | translate }}
       </th>
-      <td mat-cell *matCellDef="let element">{{ element.revisionNumber }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.editor }}</td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/libs/damap/src/lib/components/version/version-table/version-table.component.ts
+++ b/libs/damap/src/lib/components/version/version-table/version-table.component.ts
@@ -9,7 +9,7 @@ import { Dmp } from '../../../domain/dmp';
   styleUrls: ['./version-table.component.css'],
 })
 export class VersionTableComponent {
-  displayedColumns: string[] = ['version', 'name', 'date', 'revision'];
+  displayedColumns: string[] = ['version', 'name', 'date', 'editor'];
 
   @Input() dmp: DmpListItem | Dmp;
   @Input() versions: Version[];

--- a/libs/damap/src/lib/domain/version.ts
+++ b/libs/damap/src/lib/domain/version.ts
@@ -4,4 +4,5 @@ export interface Version {
   readonly revisionNumber: number;
   readonly versionName: string;
   readonly versionDate: Date;
+  readonly editor: string;
 }


### PR DESCRIPTION
Related to issue 50 in the backend: https://github.com/tuwien-csd/damap-backend/issues/50

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Feature

#### What does this PR do?

The version table now displays editor instead of revision number.

#### Dependencies

This PR needs the changes from issue 50 from the backend https://github.com/tuwien-csd/damap-backend/issues/50 to work correctly.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-39
