### PR TITLE
Fix Bug: Reload Default List After Removing a Project

### DIFF
--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -47,7 +47,6 @@ export class PeopleComponent implements OnInit, OnDestroy {
   searchResult$: Observable<SearchResult<Contributor>>;
   serviceConfig$: ServiceConfig[];
   serviceConfigType: ServiceConfig;
-  currentSearchTerm: '';
 
   constructor(
     private backendService: BackendService,
@@ -72,10 +71,8 @@ export class PeopleComponent implements OnInit, OnDestroy {
   }
 
   onServiceConfigChange(serviceConfigType: ServiceConfig) {
-    if (this.currentSearchTerm) {
-      this.serviceConfigType = serviceConfigType;
-      this.searchTerms.next(this.personSearch.currentSearchTerm);
-    }
+    this.serviceConfigType = serviceConfigType;
+    this.searchTerms.next(this.personSearch.currentSearchTerm);
   }
 
   ngOnDestroy(): void {

--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -47,6 +47,7 @@ export class PeopleComponent implements OnInit, OnDestroy {
   searchResult$: Observable<SearchResult<Contributor>>;
   serviceConfig$: ServiceConfig[];
   serviceConfigType: ServiceConfig;
+  currentSearchTerm: '';
 
   constructor(
     private backendService: BackendService,
@@ -71,8 +72,10 @@ export class PeopleComponent implements OnInit, OnDestroy {
   }
 
   onServiceConfigChange(serviceConfigType: ServiceConfig) {
-    this.serviceConfigType = serviceConfigType;
-    this.searchTerms.next(this.personSearch.currentSearchTerm);
+    if (this.currentSearchTerm) {
+      this.serviceConfigType = serviceConfigType;
+      this.searchTerms.next(this.personSearch.currentSearchTerm);
+    }
   }
 
   ngOnDestroy(): void {

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
@@ -13,6 +13,7 @@ import { BackendService } from '@damap/core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
@@ -48,6 +49,7 @@ describe('ProjectListComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatInputModule,
+        MatIconModule,
         MatListModule,
         NoopAnimationsModule,
       ],
@@ -59,34 +61,16 @@ describe('ProjectListComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);
-  });
-
-  it('should call fetchRecommendedProjects when selectedProject is set to null', () => {
-    spyOn(component, 'fetchRecommendedProjects');
-    component.selectedProject = null;
-    expect(component.fetchRecommendedProjects).toHaveBeenCalled();
+    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should fetch recommended projects when search term is null or empty', fakeAsync(() => {
-    component.fetchRecommendedProjects();
-    tick();
-    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
-
-    component.search(null);
-    tick();
-    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
-
-    component.search('');
-    tick();
-    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
-  }));
-
-  it('should use getRecommendedProjects when fetchRecommendedProjects is called', () => {
-    component.fetchRecommendedProjects();
+  it('should fetch recommended projects after creation', async () => {
+    // making sure that the input is initialized
+    await loader.getHarness(MatInputHarness);
     expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
   });
 
@@ -95,6 +79,9 @@ describe('ProjectListComponent', () => {
 
     await input.setValue(mockProject.title);
     expect(backendSpy.getProjectSearchResult).toHaveBeenCalled();
+
+    await input.setValue('');
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
   });
 
   it('should change project on selection', async () => {
@@ -111,5 +98,26 @@ describe('ProjectListComponent', () => {
 
     await options[0].select();
     expect(component.projectToSet.emit).toHaveBeenCalled();
+  });
+
+  it('should call fetchRecommendedProjects when selectedProject is set to null', () => {
+    spyOn(component, 'fetchRecommendedProjects');
+    component.selectedProject = null;
+    expect(component.fetchRecommendedProjects).toHaveBeenCalled();
+  });
+
+  it('should use getRecommendedProjects when fetchRecommendedProjects is called', fakeAsync(() => {
+    component.ngOnInit();
+    fixture.detectChanges();
+    component.fetchRecommendedProjects();
+    tick(300);
+    fixture.detectChanges();
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
+  }));
+
+  it('should load projects on text input', async () => {
+    const input = await loader.getHarness(MatInputHarness);
+    await input.setValue(mockProject.title);
+    expect(backendSpy.getProjectSearchResult).toHaveBeenCalled();
   });
 });

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
@@ -1,23 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { HarnessLoader } from '@angular/cdk/testing';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatInputHarness } from '@angular/material/input/testing';
-import { MatListModule } from '@angular/material/list';
-import { MatSelectionListHarness } from '@angular/material/list/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { BackendService } from '@damap/core';
-import { of } from 'rxjs';
-import { mockProject } from '../../../../mocks/project-mocks';
 import {
   mockProjectSearchResult,
   mockRecommendedProjectSearchResult,
 } from '../../../../mocks/search';
-import { TranslateTestingModule } from '../../../../testing/translate-testing/translate-testing.module';
+
+import { BackendService } from '@damap/core';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatSelectionListHarness } from '@angular/material/list/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ProjectListComponent } from './project-list.component';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { TranslateTestingModule } from '../../../../testing/translate-testing/translate-testing.module';
+import { mockProject } from '../../../../mocks/project-mocks';
+import { of } from 'rxjs';
 
 describe('ProjectListComponent', () => {
   let component: ProjectListComponent;
@@ -60,20 +60,12 @@ describe('ProjectListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should fetch recommended projects after creation', async () => {
-    // making sure that the input is initialized
-    await loader.getHarness(MatInputHarness);
-    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
-  });
 
   it('should load projects on text input', async () => {
     const input = await loader.getHarness(MatInputHarness);
 
     await input.setValue(mockProject.title);
     expect(backendSpy.getProjectSearchResult).toHaveBeenCalled();
-
-    await input.setValue('');
-    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
   });
 
   it('should change project on selection', async () => {

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import {
   mockProjectSearchResult,
   mockRecommendedProjectSearchResult,
@@ -56,10 +61,34 @@ describe('ProjectListComponent', () => {
     loader = TestbedHarnessEnvironment.loader(fixture);
   });
 
+  it('should call fetchRecommendedProjects when selectedProject is set to null', () => {
+    spyOn(component, 'fetchRecommendedProjects');
+    component.selectedProject = null;
+    expect(component.fetchRecommendedProjects).toHaveBeenCalled();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should fetch recommended projects when search term is null or empty', fakeAsync(() => {
+    component.fetchRecommendedProjects();
+    tick();
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
+
+    component.search(null);
+    tick();
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
+
+    component.search('');
+    tick();
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
+  }));
+
+  it('should use getRecommendedProjects when fetchRecommendedProjects is called', () => {
+    component.fetchRecommendedProjects();
+    expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
+  });
 
   it('should load projects on text input', async () => {
     const input = await loader.getHarness(MatInputHarness);

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
@@ -36,7 +36,6 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
   }
 
   set selectedProject(project: Project) {
-    console.log('selectedProject setter called', project);
     this._selectedProject = project;
     if (project === null) {
       this.fetchRecommendedProjects();

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
@@ -12,6 +12,7 @@ import {
   debounceTime,
   distinctUntilChanged,
   merge,
+  of,
   switchMap,
 } from 'rxjs';
 
@@ -51,17 +52,26 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
   ) {}
 
   ngOnInit(): void {
-    this.searchResult$ = this.searchTerms.pipe(
-      debounceTime(300),
-      distinctUntilChanged(),
-      switchMap((term: string) =>
-        this.backendService.getProjectSearchResult(term)
+    this.fetchDefaultRecommendedProjects();
+    this.searchTerms
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((term: string) =>
+          term === null || term.length === 0
+            ? this.backendService.getRecommendedProjects()
+            : this.backendService.getProjectSearchResult(term)
+        )
       )
-    );
+      .subscribe(results => (this.searchResult$ = of(results)));
   }
 
   ngAfterViewInit(): void {
     this.search(null);
+  }
+
+  fetchDefaultRecommendedProjects(): void {
+    this.searchResult$ = this.backendService.getRecommendedProjects();
   }
 
   fetchRecommendedProjects(): void {

--- a/libs/damap/src/lib/components/dmp/project/project.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/project/project.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BackendService } from '../../../services/backend.service';
-import { By } from '@angular/platform-browser';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { ProjectComponent } from './project.component';
@@ -50,21 +49,5 @@ describe('ProjectComponent', () => {
     spyOn(component.project, 'emit');
     component.changeProject(mockProject);
     expect(component.project.emit).toHaveBeenCalledWith(mockProject);
-  });
-
-  it('should call fetchRecommendedProjects on null project', () => {
-    component.changeProject(null);
-    fixture.detectChanges();
-
-    const childComponent = fixture.debugElement.query(
-      By.directive(ProjectListComponent)
-    ).componentInstance;
-
-    if (childComponent) {
-      childComponent.fetchRecommendedProjects();
-      expect(backendSpy.getRecommendedProjects).toHaveBeenCalled();
-    } else {
-      fail('ProjectListComponent is not initialized');
-    }
   });
 });

--- a/libs/damap/src/lib/components/dmp/project/project.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project.component.ts
@@ -5,9 +5,11 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+
 import { MatTabGroup } from '@angular/material/tabs';
 import { Project } from '../../../domain/project';
+import { ProjectListComponent } from './project-list/project-list.component';
+import { UntypedFormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-dmp-project',
@@ -16,13 +18,22 @@ import { Project } from '../../../domain/project';
 })
 export class ProjectComponent {
   @Input() projectStep: UntypedFormControl;
-
+  @ViewChild(ProjectListComponent) projectList: ProjectListComponent;
   @Output() project = new EventEmitter<any>();
 
   @ViewChild('tabGroup') tabGroup: MatTabGroup;
 
   changeProject(project: Project): void {
+    console.log(this.projectList);
     this.project.emit(project);
+    if (project === null) {
+      // Check if projectList reference is available
+      if (this.projectList) {
+        this.projectList.fetchRecommendedProjects();
+      } else {
+        console.error('projectList is not available');
+      }
+    }
   }
 
   changeTab(index: number): void {

--- a/libs/damap/src/lib/components/dmp/project/project.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project.component.ts
@@ -8,7 +8,6 @@ import {
 
 import { MatTabGroup } from '@angular/material/tabs';
 import { Project } from '../../../domain/project';
-import { ProjectListComponent } from './project-list/project-list.component';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({
@@ -18,18 +17,12 @@ import { UntypedFormControl } from '@angular/forms';
 })
 export class ProjectComponent {
   @Input() projectStep: UntypedFormControl;
-  @ViewChild(ProjectListComponent) projectList: ProjectListComponent;
   @Output() project = new EventEmitter<any>();
 
   @ViewChild('tabGroup') tabGroup: MatTabGroup;
 
   changeProject(project: Project): void {
     this.project.emit(project);
-    if (project === null) {
-      if (this.projectList) {
-        this.projectList.fetchRecommendedProjects();
-      }
-    }
   }
 
   changeTab(index: number): void {

--- a/libs/damap/src/lib/components/dmp/project/project.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project.component.ts
@@ -24,14 +24,10 @@ export class ProjectComponent {
   @ViewChild('tabGroup') tabGroup: MatTabGroup;
 
   changeProject(project: Project): void {
-    console.log(this.projectList);
     this.project.emit(project);
     if (project === null) {
-      // Check if projectList reference is available
       if (this.projectList) {
         this.projectList.fetchRecommendedProjects();
-      } else {
-        console.error('projectList is not available');
       }
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Displaying projects in the Project List component. Previously, when removing a project, the recommended projects were shown, but searching for new terms did not display search result

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
