### PR TITLE
config: hide data upload if FITS service not available

### DIFF
--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -9,6 +9,7 @@
   </mat-step>
   <mat-step label="{{ 'dmp.steps.people.label' | translate }}">
     <app-dmp-people
+      [config$]="config$"
       [projectMembers]="projectMembers"
       [dmpForm]="dmpForm"
       (contactPerson)="changeContactPerson($event)"
@@ -20,6 +21,7 @@
     label="{{ 'dmp.steps.data.specify.label' | translate }}"
     [hasError]="specifyDataStep.invalid || datasets.invalid">
     <app-dmp-specify-data
+      [config$]="config$"
       [specifyDataStep]="specifyDataStep"
       [datasets]="datasets"
       [fileUpload]="fileUpload"

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -1,6 +1,6 @@
 import { ActivatedRoute, Router } from '@angular/router';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { Subject, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import {
   UntypedFormArray,
@@ -27,6 +27,7 @@ import { LoggerService } from '../../services/logger.service';
 import { MatStepper } from '@angular/material/stepper';
 import { Project } from '../../domain/project';
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
+import { Config } from '../../domain/config';
 
 @Component({
   selector: 'app-dmp',
@@ -34,6 +35,8 @@ import { StepperSelectionEvent } from '@angular/cdk/stepper';
   styleUrls: ['./dmp.component.css'],
 })
 export class DmpComponent implements OnInit, OnDestroy {
+  config$: Observable<Config> = new Observable<Config>();
+
   get username(): string {
     return this.auth.getUsername();
   }
@@ -80,6 +83,7 @@ export class DmpComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.config$ = this.backendService.loadServiceConfig();
     this.getDmpById();
 
     this.dmpForm.valueChanges.subscribe(value => {

--- a/libs/damap/src/lib/components/dmp/people/people.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.spec.ts
@@ -27,23 +27,19 @@ import { PeopleComponent } from './people.component';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TranslateTestingModule } from '../../../testing/translate-testing/translate-testing.module';
 import { mockContributorSearchResult } from '../../../mocks/search';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
+import { Config } from '../../../domain/config';
 
 describe('PeopleComponent', () => {
   let component: PeopleComponent;
   let fixture: ComponentFixture<PeopleComponent>;
   let backendSpy;
-  let loadServiceConfigSpy;
   let loader: HarnessLoader;
 
   beforeEach(async () => {
     backendSpy = jasmine.createSpyObj('BackendService', [
-      'loadServiceConfig',
       'getPersonSearchResult',
     ]);
-    loadServiceConfigSpy = backendSpy.loadServiceConfig.and.returnValue(
-      of(configMockData),
-    );
     backendSpy.getPersonSearchResult.and.returnValue(
       of(mockContributorSearchResult),
     );
@@ -65,6 +61,7 @@ describe('PeopleComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PeopleComponent);
     component = fixture.componentInstance;
+    component.config$ = new BehaviorSubject<Config>(configMockData);
     component.dmpForm = new UntypedFormGroup({
       datasets: new UntypedFormArray([]),
       contributors: new UntypedFormArray([
@@ -84,8 +81,6 @@ describe('PeopleComponent', () => {
   describe('ngOnInit', () => {
     it('should load service config and set serviceConfigType to the first one', () => {
       component.ngOnInit();
-
-      expect(loadServiceConfigSpy).toHaveBeenCalled();
       expect(component.serviceConfig$).toEqual(serviceConfigMockData);
       expect(component.serviceConfigType).toEqual(serviceConfigMockData[0]);
     });

--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -20,6 +20,7 @@ import { ContributorRole } from '../../../domain/enum/contributor-role.enum';
 import { IdentifierType } from '../../../domain/enum/identifier-type.enum';
 import { BackendService } from '../../../services/backend.service';
 import { PersonSearchComponent } from '../../../widgets/person-search/person-search.component';
+import { Config } from '../../../domain/config';
 
 @Component({
   selector: 'app-dmp-people',
@@ -29,6 +30,7 @@ import { PersonSearchComponent } from '../../../widgets/person-search/person-sea
 export class PeopleComponent implements OnInit, OnDestroy {
   @ViewChild(PersonSearchComponent) personSearch: PersonSearchComponent;
 
+  @Input() config$: Observable<Config>;
   @Input() projectMembers: Contributor[];
   @Input() dmpForm: UntypedFormGroup;
 
@@ -43,6 +45,7 @@ export class PeopleComponent implements OnInit, OnDestroy {
 
   private searchTerms = new Subject<string>();
   private subscriptions: Subscription[] = [];
+  private configSubscription: Subscription;
 
   searchResult$: Observable<SearchResult<Contributor>>;
   serviceConfig$: ServiceConfig[];
@@ -54,9 +57,9 @@ export class PeopleComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.backendService.loadServiceConfig().subscribe(service => {
-      this.serviceConfig$ = service.personSearchServiceConfigs;
-      this.serviceConfigType = service.personSearchServiceConfigs[0];
+    this.configSubscription = this.config$.subscribe(config => {
+      this.serviceConfig$ = config.personSearchServiceConfigs;
+      this.serviceConfigType = config.personSearchServiceConfigs[0];
     });
 
     const searchSubscription = this.searchTerms
@@ -77,6 +80,7 @@ export class PeopleComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());
+    this.configSubscription.unsubscribe();
   }
 
   changeContactPerson(contact: Contributor): void {

--- a/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.html
@@ -8,7 +8,9 @@
         {{ "dmp.steps.data.specify.button.add.manual" | translate }}
       </button>
     </mat-tab>
-    <mat-tab label="{{ 'dmp.steps.data.specify.tab.upload' | translate }}">
+    <mat-tab
+      *ngIf="fitsServiceAvailable"
+      label="{{ 'dmp.steps.data.specify.tab.upload' | translate }}">
       <app-file-upload
         [fileUpload]="fileUpload"
         (fileToUpload)="analyseFile($event)"

--- a/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.spec.ts
@@ -6,6 +6,11 @@ import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { DataKind } from '../../../../domain/enum/data-kind.enum';
 import { MatDialogModule } from '@angular/material/dialog';
 import { DatasetDialogComponent } from '../dataset-dialog/dataset-dialog.component';
+import { BehaviorSubject } from 'rxjs';
+import { Config } from '../../../../domain/config';
+import { configMockData } from '../../../../mocks/config-service-mocks';
+import { By } from '@angular/platform-browser';
+import { FileUploadComponent } from '../../../../widgets/file-upload/file-upload.component';
 
 describe('CreatedDataComponent', () => {
   let component: CreatedDataComponent;
@@ -21,6 +26,7 @@ describe('CreatedDataComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreatedDataComponent);
     component = fixture.componentInstance;
+    component.config$ = new BehaviorSubject<Config>(configMockData);
     component.specifyDataStep = new UntypedFormGroup({
       kind: new UntypedFormControl(DataKind.NONE),
       explanation: new UntypedFormControl(''),
@@ -30,6 +36,31 @@ describe('CreatedDataComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('should load service config and set FITS service availability flag', () => {
+      component.ngOnInit();
+      expect(component.fitsServiceAvailable).toEqual(
+        configMockData.fitsServiceAvailable,
+      );
+    });
+  });
+
+  it('file upload not available if no FITS service available', () => {
+    component.fitsServiceAvailable = false;
+    const element = fixture.debugElement.query(
+      By.directive(FileUploadComponent),
+    );
+    expect(element).toBeNull();
+  });
+
+  it('file upload available if FITS service available', () => {
+    component.fitsServiceAvailable = true;
+    const element = fixture.debugElement.query(
+      By.directive(FileUploadComponent),
+    );
+    expect(element).toBeDefined();
   });
 
   it('should emit file to analyse', () => {

--- a/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.ts
@@ -1,19 +1,35 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { AbstractBaseDataComponent } from '../abstract-base-data.component';
 import { DatasetDialogComponent } from '../dataset-dialog/dataset-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
+import { Config } from '../../../../domain/config';
+import { Observable, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-created-data',
   templateUrl: './created-data.component.html',
   styleUrls: [],
 })
-export class CreatedDataComponent extends AbstractBaseDataComponent {
+export class CreatedDataComponent
+  extends AbstractBaseDataComponent
+  implements OnInit, OnDestroy
+{
   @Input() fileUpload: { file: File; progress: number; finalized: boolean }[];
+  @Input() config$: Observable<Config>;
 
   @Output() fileToAnalyse = new EventEmitter<File>();
   @Output() uploadToCancel = new EventEmitter<number>();
+
+  fitsServiceAvailable: boolean = false;
+  configSubscription: Subscription;
 
   readonly tableHeaders: string[] = [
     'dataset',
@@ -25,6 +41,16 @@ export class CreatedDataComponent extends AbstractBaseDataComponent {
 
   constructor(public dialog: MatDialog) {
     super();
+  }
+
+  ngOnInit(): void {
+    this.configSubscription = this.config$.subscribe(config => {
+      this.fitsServiceAvailable = config.fitsServiceAvailable || false;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.configSubscription.unsubscribe();
   }
 
   openDatasetDialog() {

--- a/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.html
@@ -4,6 +4,7 @@
     [specifyDataStep]="specifyDataStep"
     [datasets]="datasets"
     [fileUpload]="fileUpload"
+    [config$]="config$"
     (datasetToAdd)="add($event)"
     (updateDataset)="update($event)"
     (removeDataset)="remove($event)"

--- a/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { AbstractBaseDataComponent } from './abstract-base-data.component';
 import { UntypedFormControl } from '@angular/forms';
+import { Config } from '../../../domain/config';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-dmp-specify-data',
@@ -9,6 +11,7 @@ import { UntypedFormControl } from '@angular/forms';
 })
 export class SpecifyDataComponent extends AbstractBaseDataComponent {
   @Input() fileUpload: { file: File; progress: number; finalized: boolean }[];
+  @Input() config$: Observable<Config>;
 
   @Output() fileToAnalyse = new EventEmitter<File>();
   @Output() uploadToCancel = new EventEmitter<number>();

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -7,4 +7,5 @@ export interface Config {
   readonly authUser: string;
   readonly env: string;
   readonly personSearchServiceConfigs: ServiceConfig[];
+  readonly fitsServiceAvailable: boolean;
 }

--- a/libs/damap/src/lib/mocks/config-service-mocks.ts
+++ b/libs/damap/src/lib/mocks/config-service-mocks.ts
@@ -15,4 +15,5 @@ export const configMockData: Config = {
   authUser: '',
   env: '',
   personSearchServiceConfigs: serviceConfigMockData,
+  fitsServiceAvailable: true,
 };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix: Checks whether the backend offers a FITS service and if not hides the tab to upload files.
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
Previously the upload data tab was always displayed even when the backend did not offer that service. By checking the config sent by the BE the tab is now hidden if the service is not avialable.
<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Breaking changes
Requires the new field "fitsServiceAvailable" in "ConfigDO". If this field is not available then it assumes this service is not available and the "upload files" tab is hidden.
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
Previously only the "people" compoment accessed the config. In order to prevent the config to be loaded in each component seperately the rest call has been moved to the root component "dmp" and the config is passed down as an observable.

<!-- What you want the reviewer to focus on -->

#### Dependencies
Depends on changes in the backend that add a new field to ConfigDO
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes tuwien-csd/damap-backend#59
