### PR TITLE
Global: Change date picker to always use utc

### DIFF
--- a/libs/damap/src/lib/components/dmp/licenses/licenses.module.ts
+++ b/libs/damap/src/lib/components/dmp/licenses/licenses.module.ts
@@ -2,13 +2,23 @@ import { CommonModule } from '@angular/common';
 import { DataDeletionModule } from '../data-deletion/data-deletion.module';
 import { LicenseWizardModule } from '../../../widgets/license-wizard/license-wizard.module';
 import { LicensesComponent } from './licenses.component';
-import { MAT_DATE_LOCALE } from '@angular/material/core';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MAT_DATE_LOCALE,
+} from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatSelectModule } from '@angular/material/select';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StepIntroModule } from '../../../widgets/step-intro/step-intro.module';
 import { TranslateModule } from '@ngx-translate/core';
+import {
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+  MAT_MOMENT_DATE_FORMATS,
+  MatMomentDateModule,
+  MomentDateAdapter,
+} from '@angular/material-moment-adapter';
 
 @NgModule({
   imports: [
@@ -22,6 +32,7 @@ import { TranslateModule } from '@ngx-translate/core';
     // Materials
     MatSelectModule,
     MatDatepickerModule,
+    MatMomentDateModule,
   ],
   declarations: [LicensesComponent],
   exports: [
@@ -37,6 +48,15 @@ import { TranslateModule } from '@ngx-translate/core';
     MatSelectModule,
     MatDatepickerModule,
   ],
-  providers: [{ provide: MAT_DATE_LOCALE, useValue: 'en-GB' }],
+  providers: [
+    { provide: MAT_DATE_LOCALE, useValue: 'en-GB' },
+    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } },
+    {
+      provide: DateAdapter,
+      useClass: MomentDateAdapter,
+      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS],
+    },
+    { provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS },
+  ],
 })
 export class LicensesModule {}

--- a/libs/damap/src/lib/components/dmp/project/project.module.ts
+++ b/libs/damap/src/lib/components/dmp/project/project.module.ts
@@ -1,7 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { ErrorMessageModule } from '../../../widgets/error-message/error-message.module';
 import { InfoMessageModule } from '../../../widgets/info-message/info-message.module';
-import { MAT_DATE_LOCALE } from '@angular/material/core';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MAT_DATE_LOCALE,
+} from '@angular/material/core';
 import { ManualProjectInputComponent } from './manual-project-input/manual-project-input.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -17,6 +21,12 @@ import { ProjectComponent } from './project.component';
 import { ProjectListComponent } from './project-list/project-list.component';
 import { SharedModule } from '../../../shared/shared.module';
 import { TranslateModule } from '@ngx-translate/core';
+import {
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+  MAT_MOMENT_DATE_FORMATS,
+  MatMomentDateModule,
+  MomentDateAdapter,
+} from '@angular/material-moment-adapter';
 
 @NgModule({
   imports: [
@@ -35,6 +45,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatListModule,
     MatTooltipModule,
     MatDatepickerModule,
+    MatMomentDateModule,
     MatTabsModule,
   ],
   declarations: [
@@ -61,6 +72,15 @@ import { TranslateModule } from '@ngx-translate/core';
     MatDatepickerModule,
     MatTabsModule,
   ],
-  providers: [{ provide: MAT_DATE_LOCALE, useValue: 'en-GB' }],
+  providers: [
+    { provide: MAT_DATE_LOCALE, useValue: 'en-GB' },
+    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } },
+    {
+      provide: DateAdapter,
+      useClass: MomentDateAdapter,
+      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS],
+    },
+    { provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS },
+  ],
 })
 export class ProjectModule {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/core": "17.1.2",
         "@angular/forms": "17.1.2",
         "@angular/material": "17.1.2",
+        "@angular/material-moment-adapter": "^17.1.2",
         "@angular/platform-browser": "17.1.2",
         "@angular/platform-browser-dynamic": "17.1.2",
         "@angular/router": "17.1.2",
@@ -778,6 +779,19 @@
         "@angular/forms": "^17.0.0 || ^18.0.0",
         "@angular/platform-browser": "^17.0.0 || ^18.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material-moment-adapter": {
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-17.1.2.tgz",
+      "integrity": "sha512-UqoJSgE+zI5sUAn6ae46OSsUQR6rVTyXCCDzr6WPYaeRcnbMzrtZoUYLPlzfLbqOePO/GQR9tsNPI4lAlzYR0g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^17.0.0 || ^18.0.0",
+        "@angular/material": "17.1.2",
+        "moment": "^2.18.1"
       }
     },
     "node_modules/@angular/platform-browser": {
@@ -17084,6 +17098,15 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@angular/core": "17.1.2",
     "@angular/forms": "17.1.2",
     "@angular/material": "17.1.2",
+    "@angular/material-moment-adapter": "17.1.2",
     "@angular/platform-browser": "17.1.2",
     "@angular/platform-browser-dynamic": "17.1.2",
     "@angular/router": "17.1.2",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

Adds providers to datepickers that configure them to use the UTC date format - before they would use the local timezone, which would lead to date jumps, since they were converted to UTC in the backen. E.g. 01.06.2024 00:00 GMT+2 would become 31.05.2024 22:00 UTC.

#### Code review focus

Test extensively, the bug occured less often on my local machine - so maybe it is not fixed. 
If it is fixed, remove the code block 
```
{
      provide: DateAdapter,
      useClass: MomentDateAdapter,
      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS],
    },
    { provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS },
```
from the providers array in `licenses.module.ts` and `project.module.ts`. I needed these to make it work, but the Angular docs do not mention them.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-204
