### PR TITLE
Global: Remove two unneeded ui-elements

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -103,7 +103,7 @@
               "comment": "Comment",
               "actions": "Actions",
               "description": "Description",
-              "pid": "PID"
+              "source": "Source"
             }
           },
           "dialog": {

--- a/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
@@ -18,9 +18,6 @@
             <mat-card-title [class.form-error]="item.invalid">
               {{ item.value.title }}
             </mat-card-title>
-            <mat-panel-description>
-              {{ item.value.backupLocation }}
-            </mat-panel-description>
           </mat-card-header>
         </div>
         <mat-card-content>

--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-dialog/dataset-dialog.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-dialog/dataset-dialog.component.html
@@ -55,18 +55,6 @@
     *ngIf="dataset.controls.source.value === datasetSource.REUSED">
     <mat-form-field>
       <mat-label>{{
-        "dmp.steps.data.specify.dialog.identifier" | translate
-      }}</mat-label>
-      <mat-select [(ngModel)]="datasetId.type">
-        <mat-option
-          *ngFor="let id of identifierTypeReusedData | keyvalue: originalOrder"
-          [value]="id.key">
-          {{ id.key }}<br />
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>{{
         "dmp.steps.data.specify.dialog.source" | translate
       }}</mat-label>
       <input matInput [(ngModel)]="datasetId.identifier" maxlength="255" />

--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
@@ -49,9 +49,9 @@
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="pid">
+    <ng-container matColumnDef="source">
       <th mat-header-cell *matHeaderCellDef>
-        {{ "dmp.steps.data.specify.table.header.pid" | translate }}
+        {{ "dmp.steps.data.specify.table.header.source" | translate }}
       </th>
       <td mat-cell *matCellDef="let dataset">
         <div>

--- a/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.ts
@@ -23,7 +23,7 @@ export class ReusedDataComponent
 
   result: Dataset;
 
-  readonly tableHeaders: string[] = ['dataset', 'pid', 'actions'];
+  readonly tableHeaders: string[] = ['dataset', 'source', 'actions'];
 
   constructor(
     private backendService: BackendService,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

Removed the following elements on Tomek's & Christiane's behest:

![image](https://github.com/tuwien-csd/damap-frontend/assets/80054001/206ae80c-832f-4835-8a2d-7098de0eb743)

![image](https://github.com/tuwien-csd/damap-frontend/assets/80054001/cd369011-6601-48e9-bb46-0842628c7587)

This is related to https://github.com/tuwien-csd/damap-backend/issues/192

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-210
