### PR TITLE
Datastep: Hide date input field when dataset is closed

### DIFF
--- a/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
+++ b/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
@@ -73,7 +73,8 @@
           </mat-card-content>
         </ng-container>
 
-        <mat-card-content>
+        <mat-card-content
+          *ngIf="dataset.value.dataAccess !== accessType.CLOSED">
           <mat-form-field>
             <mat-label>{{
               "dmp.steps.licensing.question.startDate" | translate

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -1,4 +1,4 @@
-import { Contributor, compareContributors } from '../domain/contributor';
+import { compareContributors, Contributor } from '../domain/contributor';
 import {
   FormControl,
   UntypedFormArray,
@@ -238,7 +238,7 @@ export class FormService {
       reusedDataKind: formValue.data.reusedKind,
       dataQuality: formValue.documentation.dataQuality || [],
       documentation: formValue.documentation.documentation,
-      datasets: formValue.datasets,
+      datasets: formValue.datasets.map(this.setStartDateToNullWhenClosed),
       ethicalIssuesExist: formValue.legal.ethicalIssues,
       ethicalIssuesExistCris: formValue.legal.ethicalIssuesCris,
       externalStorage: formValue.externalStorage,
@@ -649,5 +649,12 @@ export class FormService {
     } else {
       return null;
     }
+  }
+
+  private setStartDateToNullWhenClosed(dataset: Dataset): Dataset {
+    if (dataset.dataAccess === DataAccessType.CLOSED) {
+      dataset.startDate = null;
+    }
+    return dataset;
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?

Hides the date input field in step 7 when the dataset is closed, since it doesnt need a publication date. Also sets the startdate to null on save, when the dataset is closed.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-218
