### PR TITLE
Shared: Make autocomplete panel responsive to resize of textarea-wrapper

### DIFF
--- a/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.css
+++ b/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.css
@@ -14,3 +14,7 @@ mat-form-field {
   );
   box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.3);
 }
+
+.no-resize {
+  resize: none;
+}

--- a/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.html
+++ b/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.html
@@ -11,7 +11,10 @@
       type="text"
       [required]="required"
       [maxLength]="maxLength"
-      rows="4"
+      cdkTextareaAutosize
+      cdkAutosizeMinRows="5"
+      cdkAutosizeMaxRows="9"
+      class="no-resize"
       #message>
     </textarea>
     <mat-hint align="end"
@@ -28,7 +31,11 @@
       type="text"
       [matAutocomplete]="auto"
       [required]="required"
-      rows="4"
+      cdkTextareaAutosize
+      cdkAutosizeMinRows="5"
+      cdkAutosizeMaxRows="9"
+      class="no-resize"
+      (input)="this.updateAutocompletePosition()"
       #message></textarea>
     <mat-hint align="end"
       >{{ message.value.length }} / {{ maxLength }}</mat-hint

--- a/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.ts
+++ b/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
 
 import { MatFormFieldAppearance } from '@angular/material/form-field';
+import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 
 @Component({
   selector: 'app-textarea-wrapper [label] [control]',
@@ -16,10 +17,18 @@ export class TextareaWrapperComponent implements OnInit {
   @Input() appearance: MatFormFieldAppearance = 'fill';
   @Input() maxLength = 4000;
   @Input() applyCustomStyle = false;
+  @ViewChild(MatAutocompleteTrigger)
+  autocompleteTrigger: MatAutocompleteTrigger;
 
   required = false;
 
   ngOnInit(): void {
     this.required = this.control?.hasValidator(Validators.required);
+  }
+
+  updateAutocompletePosition() {
+    if (this.autocompleteTrigger) {
+      this.autocompleteTrigger.updatePosition();
+    }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

Before, the autocomplete panel would stay where it was, even if the textarea was resized - this can lead to loss of progress, since the autocomplete can overwrite the textarea. Now the panel resizes together with the textarea. I also removed the manual resizing option and made the textarea scale automatically up until 9 lines or ~ 200 words. If the limit is reached, the user has to scroll inside the textarea. According to Christiane almost no one writes that many words, so it should be fine this way. The manual resize button also took space away from the scrolling bar inside the textarea, that is another reason why i removed it, see the screenshot.

<img width="63" alt="image" src="https://github.com/tuwien-csd/damap-frontend/assets/80054001/86831e57-ba41-41e7-8e39-1a81c8e1a0f9">

I also tried to remove the behaviour that the autocomplete option overwrites everything in the textarea, but it seems this will not be supported any time soon: https://github.com/angular/components/issues/12144
I also could not find a workaround :/

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-230
