### PR TITLE
access: add ng-content to person card to show child content

### DIFF
--- a/libs/damap/src/lib/widgets/person-card/person-card.component.html
+++ b/libs/damap/src/lib/widgets/person-card/person-card.component.html
@@ -24,6 +24,7 @@
           "
           [orcidId]="person.personId?.identifier"></app-orcid>
       </div>
+      <ng-content></ng-content>
     </div>
   </mat-card-content>
 </mat-card>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->
Access management info was not visible.
![Screenshot from 2024-06-26 09-50-59](https://github.com/tuwien-csd/damap-frontend/assets/72449192/60fd448a-5bd4-416f-a7f8-612f302c0c2b)


Access management info is now visible again and working as expected
![image](https://github.com/tuwien-csd/damap-frontend/assets/72449192/813d2193-9b31-4c46-9855-f1137704f500)


#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->
None

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

closes #243 

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
