### PR TITLE
Display dataset size label

### DIFF
--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
@@ -36,7 +36,7 @@
         {{ "dmp.steps.data.specify.table.header.size" | translate }}
       </th>
       <td mat-cell *matCellDef="let dataset">
-        <div>{{ dataset.size | byte }}</div>
+        <div>{{ getSizeLabel(dataset.size) }}</div>
       </td>
     </ng-container>
 

--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.ts
@@ -1,9 +1,11 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { UntypedFormArray, UntypedFormGroup } from '@angular/forms';
+
 import { DataSource } from '../../../../domain/enum/data-source.enum';
-import { DatasetDialogComponent } from '../dataset-dialog/dataset-dialog.component';
-import { MatDialog } from '@angular/material/dialog';
 import { Dataset } from '../../../../domain/dataset';
+import { DatasetDialogComponent } from '../dataset-dialog/dataset-dialog.component';
+import { FILE_SIZES } from '../data-specs';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-dataset-table',
@@ -11,6 +13,7 @@ import { Dataset } from '../../../../domain/dataset';
   styleUrls: ['./dataset-table.component.css'],
 })
 export class DatasetTableComponent {
+  readonly FILE_SIZES = FILE_SIZES;
   @Input() datasets: UntypedFormArray;
   @Input() sourceType: DataSource = DataSource.NEW;
 
@@ -27,6 +30,14 @@ export class DatasetTableComponent {
   readonly datasetSource: any = DataSource;
 
   constructor(public dialog: MatDialog) {}
+
+  getSizeLabel(size: number): string {
+    if (size === -1) {
+      return "I don't know yet";
+    }
+    const foundSize = this.FILE_SIZES.find(option => size <= option.size);
+    return foundSize ? foundSize.label : 'Size not defined';
+  }
 
   openDatasetDialog(dataset: Dataset) {
     const index = this.findFormArrayIndex(dataset);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Dataset sizes are displayed, shifting from technical size notations to labels that reflect typical data size ranges (e.g., "1 - 5 GB"). 

#### What does this PR do?

![image](https://github.com/tuwien-csd/damap-frontend/assets/112856634/e640693f-ece7-4535-be46-3b540ba89eba)

#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
