### PR TITLE
Implement navbar toggle and responsive adjustments

### DIFF
--- a/apps/damap-frontend/src/app/components/layout/layout.component.css
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.css
@@ -225,10 +225,6 @@ svg {
     display: block;
   }
 
-  .sidenav-btn {
-    display: none;
-  }
-
   .mainHeaderLeft {
     background-color: var(--secondary-color);
     padding: 0;

--- a/apps/damap-frontend/src/app/components/layout/layout.component.css
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.css
@@ -1,37 +1,93 @@
 .mat-sidenav-container {
   min-height: calc(100% - 50px);
   overflow: clip;
+  display: contents;
 }
 
 .mat-sidenav-content {
   overflow: visible;
 }
 
+.mat-sidenav.collapsed .menu-icon-text {
+  display: none;
+}
+
+.menu-icon-size {
+  transform: scale(1.2) !important;
+  margin: 13px;
+}
+
+.mat-sidenav.collapsed {
+  width: 90px !important;
+}
+
+.menu-icon-text {
+  display: inline;
+  text-align: center;
+}
+
+.mat-sidenav-opened .mat-sidenav-content {
+  margin-left: 301px;
+}
+
+.mat-sidenav-collapsed .mat-sidenav-content {
+  margin-left: 90px;
+}
+
+.sidenav-btn {
+  display: block;
+  margin: 10px 23px;
+}
+
 .mat-sidenav {
   width: 301px;
-}
-
-.footer {
-  background-color: var(--footer-color);
-  color: var(--on-footer-color);
-  font-size: small;
-  padding: 1rem 2rem;
-  z-index: 10;
-  position: relative;
-  height: 50px;
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
+  overflow-y: auto;
+  -ms-overflow-style: none;
 }
 
-.footer a {
-  color: var(--on-footer-color);
-  text-decoration: none;
-  padding: 0 0.5rem;
+.mat-sidenav::-webkit-scrollbar {
+  width: 0px;
+  background: transparent;
+}
+
+.mat-nav-list {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.footer-desktop {
+  font-size: small;
+  display: flex;
+  justify-content: flex-end;
+  position: sticky;
+  bottom: 0;
+}
+
+.footer-mobile {
+  font-size: small;
+  display: flex;
+  justify-content: flex-end;
+  position: sticky;
+  bottom: 0;
+}
+
+#logout {
+  transform: scale(0.6);
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  width: 80%;
+  align-items: end;
 }
 
 mat-nav-list {
-  padding-top: 0;
-  width: 300px;
+  width: 100%;
 }
 
 .mm-navbars-top a {
@@ -39,23 +95,18 @@ mat-nav-list {
 }
 
 .mm-navbars-top {
+  line-height: 70px;
+  height: 70px;
   border-width: 0;
   overflow: hidden;
   position: absolute;
   left: 0;
   right: 0;
-  height: 50px;
 }
 
 .mm-navbar-button {
   color: var(--on-primary);
   height: 100%;
-}
-
-.info {
-  display: flex;
-  flex-direction: column;
-  text-align: right;
 }
 
 .mm-navbar {
@@ -84,13 +135,30 @@ mat-nav-list {
   font-weight: 500;
 }
 
-.languageElement {
-  width: 110px;
-  flex-basis: 110px;
-  flex-shrink: 0;
+.languageElement-desktop {
   display: flex;
-  transition: color 0.3s ease;
   justify-content: center;
+  align-items: center;
+  padding: 0;
+}
+
+.languageElement-mobile {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-top: 15px;
+  position: absolute;
+  left: 20px;
+  top: 0px;
+}
+
+.languageElement-mobile button {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  text-align: center;
 }
 
 .logo A {
@@ -104,11 +172,12 @@ mat-nav-list {
 }
 
 #user {
-  margin-top: 50px;
+  height: 35px !important;
+  margin-top: 70px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 16px;
+  padding: 8px 10px;
   background-color: var(--user-navbar-color);
 }
 
@@ -121,7 +190,7 @@ mat-nav-list {
 }
 
 #mainHeader {
-  height: 50px;
+  height: 70px;
   overflow: visible;
 }
 
@@ -142,6 +211,11 @@ svg {
   align-content: flex-end;
 }
 
+.mainHeaderLeft {
+  background-color: var(--secondary-color);
+  padding: 0;
+}
+
 .mainHeaderNav {
   display: flex;
   min-width: 50px;
@@ -150,20 +224,30 @@ svg {
 }
 
 .nav-item-desktop {
-  padding: 0 15px 0 15px;
+  padding: 0 15px;
   text-decoration: none;
   color: var(--primary);
   text-transform: uppercase;
   line-height: 70px;
   font-family: FFDINWebPro, sans-serif;
   font-weight: 700;
-  display: none;
+  display: block;
+}
+
+.mm-navbars-top .languageElement A {
+  line-height: 70px;
+  height: 70px;
 }
 
 @media (max-width: 800px) {
   #mainHeader #mainHeaderLogo A {
     position: relative;
     margin-top: 0;
+  }
+
+  .sidenav-btn {
+    display: block;
+    margin: 0px 15px;
   }
 }
 
@@ -174,6 +258,7 @@ svg {
   align-items: center;
   justify-content: end;
   width: 100px;
+  padding-right: 15px;
 }
 
 #mainHeaderLogo A svg {
@@ -194,39 +279,4 @@ svg {
   background-color: var(--surface-container-low);
   padding-left: 22px;
   font-weight: 400;
-}
-
-.sidenav-btn {
-  display: block;
-}
-
-@media only screen and (min-width: 1024px) {
-  .mm-navbars-top {
-    line-height: 70px;
-    height: 70px;
-  }
-
-  #user {
-    margin-top: 70px;
-    padding: 12px 16px;
-  }
-
-  .mm-navbars-top .languageElement A {
-    line-height: 70px;
-    height: 70px;
-  }
-
-  #mainHeader #mainHeaderLogo A {
-    padding-right: 15px;
-    position: relative;
-  }
-
-  .nav-item-desktop {
-    display: block;
-  }
-
-  .mainHeaderLeft {
-    background-color: var(--secondary-color);
-    padding: 0;
-  }
 }

--- a/apps/damap-frontend/src/app/components/layout/layout.component.html
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.html
@@ -2,9 +2,7 @@
   <mat-sidenav
     class="mat-sidenav-divider-grey"
     #sidenav
-    [fixedInViewport]="true"
-    (window:resize)="widescreen()"
-    [opened]="widescreen()"
+    [opened]="!isSmallScreen"
     mode="side">
     <div class="mm-navbars-top mat-focus-indicator">
       <div class="mm-navbar">
@@ -54,27 +52,6 @@
   <mat-sidenav-content>
     <mat-toolbar>
       <mat-toolbar-row id="mainHeader" [style]="'padding: 0px;'">
-        <div class="mainHeaderLeft">
-          <button
-            mat-icon-button
-            title="{{ 'layout.menu.mobile.open' | translate }}"
-            (click)="sidenav.opened = !sidenav.opened"
-            *ngIf="!sidenav.opened">
-            <mat-icon class="material-icon-on-secondary-container"
-              >menu</mat-icon
-            >
-          </button>
-          <button
-            mat-icon-button
-            title="{{ 'layout.menu.mobile.close' | translate }}"
-            class="sidenav-btn"
-            (click)="sidenav.opened = !sidenav.opened"
-            *ngIf="sidenav.opened">
-            <mat-icon class="material-icon-on-secondary-container"
-              >close</mat-icon
-            >
-          </button>
-        </div>
         <div class="mainHeaderRight"></div>
         <!-- University Logo -->
         <div id="mainHeaderLogo">
@@ -93,6 +70,15 @@
         <!-- University Logo End -->
       </mat-toolbar-row>
       <mat-toolbar-row class="mat-toolbar-row-grey">
+        <button
+          mat-icon-button
+          title="{{ 'layout.menu.mobile.close' | translate }}"
+          class="sidenav-btn"
+          (click)="toggleSidenav()">
+          <mat-icon class="material-icon-on-secondary-container">
+            {{ sidenav.opened ? "close" : "menu" }}
+          </mat-icon>
+        </button>
         <strong translate>title</strong>
       </mat-toolbar-row>
     </mat-toolbar>

--- a/apps/damap-frontend/src/app/components/layout/layout.component.html
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.html
@@ -1,63 +1,104 @@
-<mat-sidenav-container>
+<mat-sidenav-container autosize>
   <mat-sidenav
-    class="mat-sidenav-divider-grey"
     #sidenav
-    [opened]="!isSmallScreen"
-    mode="side">
+    [mode]="isSmallScreen ? 'side' : 'side'"
+    [opened]="true"
+    [class.collapsed]="isCollapsed"
+    [disableClose]="true"
+    class="mat-sidenav">
     <div class="mm-navbars-top mat-focus-indicator">
       <div class="mm-navbar">
+        <button
+          mat-icon-button
+          title="{{ 'layout.menu.mobile.close' | translate }}"
+          class="sidenav-btn"
+          (click)="toggleMenu()">
+          <mat-icon *ngIf="!isSmallScreen" style="color: white">{{
+            isCollapsed ? "menu" : "menu_open"
+          }}</mat-icon>
+        </button>
+
         <div class="logo">
           <a
             title="Damap"
             id="damap-logo"
             class="mat-focus-indicator"
             [routerLink]="'/'">
-            {{ "title" | translate }}
+            <span *ngIf="!isCollapsed">{{ "title" | translate }}</span>
           </a>
-        </div>
-        <div class="languageElement">
-          <button
-            mat-button
-            style="color: inherit"
-            class="mm-navbar-button"
-            [matMenuTriggerFor]="language">
-            {{ lang }}
-          </button>
-          <mat-menu #language="matMenu">
-            <button mat-menu-item (click)="useLanguage('en')">EN</button>
-            <button mat-menu-item (click)="useLanguage('de')">DE</button>
-          </mat-menu>
         </div>
       </div>
     </div>
+
     <div id="user">
-      <div>{{ name }}</div>
+      <div *ngIf="!isCollapsed" class="user-name">{{ name }}</div>
+      <div class="languageElement-desktop">
+        <button
+          mat-button
+          style="color: white"
+          class="mm-navbar-button"
+          [matMenuTriggerFor]="language">
+          {{ lang }}
+        </button>
+        <mat-menu #language="matMenu">
+          <button mat-menu-item (click)="useLanguage('en')">EN</button>
+          <button mat-menu-item (click)="useLanguage('de')">DE</button>
+        </mat-menu>
+      </div>
+    </div>
+
+    <mat-nav-list>
+      <div class="nav-list">
+        <a
+          mat-list-item
+          [routerLink]="'/dashboard'"
+          routerLinkActive="active-icon material-icon-primary"
+          [routerLinkActiveOptions]="{ exact: true }">
+          <mat-icon class="menu-icon-size">home</mat-icon>
+          <span *ngIf="!isCollapsed" class="menu-icon-text">{{
+            "layout.menu.home" | translate
+          }}</span>
+        </a>
+        <a
+          mat-list-item
+          [routerLink]="'/plans'"
+          routerLinkActive="active-icon material-icon-primary"
+          [routerLinkActiveOptions]="{ exact: true }">
+          <mat-icon class="menu-icon-size">table_view</mat-icon>
+          <span *ngIf="!isCollapsed" class="menu-icon-text">{{
+            "layout.menu.plans" | translate
+          }}</span>
+        </a>
+      </div>
+    </mat-nav-list>
+    <div
+      [ngClass]="isSmallScreen ? 'footer-mobile' : 'footer-desktop'"
+      [ngStyle]="{
+        padding: isSmallScreen
+          ? '0.5rem 1.5rem'
+          : isCollapsed
+            ? '1.5rem 1.6rem'
+            : '1.5rem 1.3rem',
+      }">
       <button
         mat-icon-button
         id="logout"
+        class="material-icon-on-secondary-container"
         [attr.aria-label]="'layout.logout' | translate"
         (click)="logout()">
-        <mat-icon class="material-icon-white">logout</mat-icon>
+        <mat-icon>logout</mat-icon>
       </button>
     </div>
-    <mat-nav-list>
-      <a mat-list-item [routerLink]="'/dashboard'" routerLinkActive="active">{{
-        "layout.menu.home" | translate
-      }}</a>
-      <a mat-list-item [routerLink]="'/plans'" routerLinkActive="active">{{
-        "layout.menu.plans" | translate
-      }}</a>
-    </mat-nav-list>
   </mat-sidenav>
+
   <mat-sidenav-content>
     <mat-toolbar>
-      <mat-toolbar-row id="mainHeader" [style]="'padding: 0px;'">
+      <mat-toolbar-row id="mainHeader" style="padding: 0">
         <div class="mainHeaderRight"></div>
-        <!-- University Logo -->
         <div id="mainHeaderLogo">
           <a
             class="mat-focus-indicator"
-            title="{{ 'layout.logo.text' | translate }}"
+            [title]="'layout.logo.text' | translate"
             [href]="'layout.logo.link' | translate"
             rel="noopener">
             <img
@@ -67,48 +108,13 @@
               width="300px" />
           </a>
         </div>
-        <!-- University Logo End -->
       </mat-toolbar-row>
       <mat-toolbar-row class="mat-toolbar-row-grey">
-        <button
-          mat-icon-button
-          title="{{ 'layout.menu.mobile.close' | translate }}"
-          class="sidenav-btn"
-          (click)="toggleSidenav()">
-          <mat-icon class="material-icon-on-secondary-container">
-            {{ sidenav.opened ? "close" : "menu" }}
-          </mat-icon>
-        </button>
-        <strong translate>title</strong>
+        <strong>{{ "title" | translate }}</strong>
       </mat-toolbar-row>
     </mat-toolbar>
+
     <app-env-banner *ngIf="env === 'DEV'"></app-env-banner>
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>
-<div class="footer">
-  <div class="version-information">
-    {{ "layout.version" | translate }}: {{ version }}
-    <a [routerLink]="'/gdpr'" rel="noopener">{{ "layout.gdpr" | translate }}</a>
-  </div>
-  <div class="info">
-    <a
-      [href]="'layout.impressum.link' | translate"
-      rel="noopener"
-      target="_blank"
-      >{{ "layout.impressum.text" | translate }}</a
-    >
-    <a
-      [href]="'layout.termsandconditions.link' | translate"
-      rel="noopener"
-      target="_blank"
-      >{{ "layout.termsandconditions.text" | translate }}</a
-    >
-    <a
-      [href]="'layout.dataprotection.link' | translate"
-      rel="noopener"
-      target="_blank"
-      >{{ "layout.dataprotection.text" | translate }}</a
-    >
-  </div>
-</div>

--- a/apps/damap-frontend/src/app/components/layout/layout.component.spec.ts
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.spec.ts
@@ -1,26 +1,37 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { By } from '@angular/platform-browser';
 import { ConfigService } from '../../services/config.service';
 import { LayoutComponent } from './layout.component';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { OAuthService } from 'angular-oauth2-oidc';
 import { TranslateTestingModule } from '@damap/core';
+import { of } from 'rxjs';
 
 describe('LayoutComponent', () => {
   let component: LayoutComponent;
   let fixture: ComponentFixture<LayoutComponent>;
+  let breakpointObserver: BreakpointObserver;
+  let sidenav: MatSidenav;
 
   beforeEach(waitForAsync(() => {
     const oauthSpy = jasmine.createSpyObj('OAuthService', [
       'getIdentityClaims',
     ]);
     oauthSpy.getIdentityClaims.and.returnValue({ name: 'name' });
+
     const configSpy = jasmine.createSpyObj('ConfigService', ['getEnvironment']);
     configSpy.getEnvironment.and.returnValue('DEV');
+
+    const breakpointObserverSpy = jasmine.createSpyObj('BreakpointObserver', [
+      'observe',
+    ]);
+    breakpointObserverSpy.observe.and.returnValue(of({ matches: false }));
 
     TestBed.configureTestingModule({
       imports: [
@@ -35,17 +46,90 @@ describe('LayoutComponent', () => {
       providers: [
         { provide: OAuthService, useValue: oauthSpy },
         { provide: ConfigService, useValue: configSpy },
+        { provide: BreakpointObserver, useValue: breakpointObserverSpy },
       ],
     }).compileComponents();
+
+    breakpointObserver = TestBed.inject(BreakpointObserver);
   }));
 
-  beforeEach(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(LayoutComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      sidenav = fixture.debugElement.query(
+        By.directive(MatSidenav),
+      ).componentInstance;
+      sidenav._content = {
+        nativeElement: document.createElement('div'),
+      } as any;
+    });
+  }));
+
+  function setScreenSize(isSmallScreen: boolean): void {
+    (breakpointObserver.observe as jasmine.Spy).and.returnValue(
+      of({ matches: isSmallScreen }),
+    );
+    component.ngOnInit();
+    fixture.detectChanges();
+  }
+
+  function toggleMenu(): void {
+    component.toggleMenu();
+    fixture.detectChanges();
+  }
+
+  it('should create the component', waitForAsync(() => {
+    fixture.whenStable().then(() => {
+      expect(component).toBeTruthy();
+    });
+  }));
+
+  it('should collapse sidenav on small screen', waitForAsync(() => {
+    (breakpointObserver.observe as jasmine.Spy).and.returnValue(
+      of({ matches: false }),
+    );
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      expect(component.isSmallScreen).toBeFalse();
+      expect(component.isCollapsed).toBeFalse();
+
+      fixture.detectChanges();
+      expect(sidenav.opened).toBeTrue();
+    });
+  }));
+
+  it('should expand sidenav on large screen', waitForAsync(() => {
+    setScreenSize(false);
+
+    fixture.whenStable().then(() => {
+      expect(component.isSmallScreen).toBeFalse();
+      expect(component.isCollapsed).toBeFalse();
+      expect(sidenav.opened).toBeTrue();
+    });
+  }));
+
+  it('should toggle the menu on desktop (isSmallScreen = false)', waitForAsync(() => {
+    setScreenSize(false);
+
+    component.isCollapsed = false;
+    toggleMenu();
+    expect(component.isCollapsed).toBeTrue();
+
+    toggleMenu();
+    expect(component.isCollapsed).toBeFalse();
+  }));
+
+  it('should not toggle the menu on mobile (isSmallScreen = true)', waitForAsync(() => {
+    setScreenSize(true);
+
+    component.isCollapsed = true;
+    toggleMenu();
+    expect(component.isCollapsed).toBeTrue();
+  }));
 });

--- a/apps/damap-frontend/src/app/components/layout/layout.component.ts
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.ts
@@ -1,11 +1,5 @@
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  HostListener,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 
 import { AuthService } from '@damap/core';
 import { ConfigService } from '../../services/config.service';
@@ -19,13 +13,14 @@ import pkg from '../../../../../../package.json'; // eslint-disable-line
   styleUrls: ['./layout.component.css'],
 })
 export class LayoutComponent implements OnInit, AfterViewInit {
-  @ViewChild('sidenav') sidenav!: MatSidenav;
+  @ViewChild('sidenav', { static: true }) sidenav!: MatSidenav;
 
   public title = 'Data Management Plan';
   public version: string = pkg.version;
   public name: string;
   public lang = 'en';
   public isSmallScreen: boolean = false;
+  public isCollapsed: boolean = false;
 
   readonly env: string;
 
@@ -33,7 +28,7 @@ export class LayoutComponent implements OnInit, AfterViewInit {
     private auth: AuthService,
     private translate: TranslateService,
     private configService: ConfigService,
-    private cdr: ChangeDetectorRef,
+    private observer: BreakpointObserver,
   ) {
     this.env = this.configService.getEnvironment();
   }
@@ -43,25 +38,19 @@ export class LayoutComponent implements OnInit, AfterViewInit {
     const browserLang = this.translate.getBrowserLang();
     this.translate.use(browserLang?.match(/en|de/) ? browserLang : 'en');
     this.lang = this.translate.currentLang.toUpperCase();
+
+    this.observer.observe([Breakpoints.Handset]).subscribe(result => {
+      this.isSmallScreen = result.matches;
+      this.checkScreenSize();
+    });
   }
 
   ngAfterViewInit(): void {
     this.checkScreenSize();
   }
 
-  @HostListener('window:resize', [])
-  onResize() {
-    this.checkScreenSize();
-  }
-
-  checkScreenSize() {
-    this.isSmallScreen = window.innerWidth < 1024;
-    if (this.isSmallScreen) {
-      this.sidenav.close();
-    } else {
-      this.sidenav.open();
-    }
-    this.cdr.detectChanges();
+  private checkScreenSize(): void {
+    this.isCollapsed = this.isSmallScreen;
   }
 
   useLanguage(language: string): void {
@@ -69,11 +58,13 @@ export class LayoutComponent implements OnInit, AfterViewInit {
     this.translate.use(language);
   }
 
-  public logout() {
+  public logout(): void {
     this.auth.logout();
   }
 
-  toggleSidenav() {
-    this.sidenav.toggle();
+  toggleMenu(): void {
+    if (!this.isSmallScreen) {
+      this.isCollapsed = !this.isCollapsed;
+    }
   }
 }

--- a/apps/damap-frontend/src/app/components/layout/layout.component.ts
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.ts
@@ -1,20 +1,31 @@
-import pkg from '../../../../../../package.json'; // eslint-disable-line
-import { Component, OnInit } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  HostListener,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
+
 import { AuthService } from '@damap/core';
 import { ConfigService } from '../../services/config.service';
+import { MatSidenav } from '@angular/material/sidenav';
+import { TranslateService } from '@ngx-translate/core';
+import pkg from '../../../../../../package.json'; // eslint-disable-line
 
 @Component({
   selector: 'app-layout',
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.css'],
 })
-export class LayoutComponent implements OnInit {
+export class LayoutComponent implements OnInit, AfterViewInit {
+  @ViewChild('sidenav') sidenav!: MatSidenav;
+
   public title = 'Data Management Plan';
   public version: string = pkg.version;
   public name: string;
   public lang = 'en';
-  public widescreen = () => window.innerWidth >= 1024;
+  public isSmallScreen: boolean = false;
 
   readonly env: string;
 
@@ -22,6 +33,7 @@ export class LayoutComponent implements OnInit {
     private auth: AuthService,
     private translate: TranslateService,
     private configService: ConfigService,
+    private cdr: ChangeDetectorRef,
   ) {
     this.env = this.configService.getEnvironment();
   }
@@ -33,6 +45,25 @@ export class LayoutComponent implements OnInit {
     this.lang = this.translate.currentLang.toUpperCase();
   }
 
+  ngAfterViewInit(): void {
+    this.checkScreenSize();
+  }
+
+  @HostListener('window:resize', [])
+  onResize() {
+    this.checkScreenSize();
+  }
+
+  checkScreenSize() {
+    this.isSmallScreen = window.innerWidth < 1024;
+    if (this.isSmallScreen) {
+      this.sidenav.close();
+    } else {
+      this.sidenav.open();
+    }
+    this.cdr.detectChanges();
+  }
+
   useLanguage(language: string): void {
     this.lang = language.toUpperCase();
     this.translate.use(language);
@@ -40,5 +71,9 @@ export class LayoutComponent implements OnInit {
 
   public logout() {
     this.auth.logout();
+  }
+
+  toggleSidenav() {
+    this.sidenav.toggle();
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?

Adds an icon near the header title to toggle the visibility of the navbar.
Ensures content area adjusts dynamically for either a wider view or a visible navbar.


<img width="952" alt="current-nav-bar" src="https://github.com/user-attachments/assets/7e335bf0-7658-41a4-b0f0-678bcb3d3aa5">

<img width="950" alt="current-nav-bar1" src="https://github.com/user-attachments/assets/ea82a0fb-7e3c-44f0-acd4-3afd1a5976db">

<img width="258" alt="current-nav-bar-mobile" src="https://github.com/user-attachments/assets/e5d934b3-9b97-415f-933c-1516dc8364c7">

#### Breaking changes

Now, since we added new features for UI and make it responsive, I have placed an icon near the current header title that toggles the navbar visibility. When implementing issue #259 (Responsive Layout), which includes a new title and description, the icon should be positioned near the new title.

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
