### PR TITLE
Translation: Add keys for manual project input

### DIFF
--- a/libs/damap/src/assets/i18n/templates/de.json
+++ b/libs/damap/src/assets/i18n/templates/de.json
@@ -5,7 +5,9 @@
         "input": {
           "title": "Projekt Titel",
           "description": "Projektbeschreibung",
-          "button": "Projekt updaten"
+          "button": "Projekt updaten",
+          "date": "Start und Enddatum",
+          "datehint": "TT/MM/JJJJ – TT/MM/JJJJ"
         }
       }
     }

--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -5,7 +5,9 @@
         "input": {
           "title": "Project title",
           "description": "Project description",
-          "button": "Update project"
+          "button": "Update project",
+          "date": "Enter start and end date",
+          "datehint": "DD/MM/YYYY – DD/MM/YYYY"
         },
         "manual.input": "Input project manually",
         "list": "Choose project from the project database",

--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
@@ -2,21 +2,25 @@
   <div class="form-row">
     <app-input-wrapper
       [control]="title"
-      label="dmp.steps.project.input.title"></app-input-wrapper>
+      label="{{
+        'dmp.steps.project.input.button' | translate
+      }}"></app-input-wrapper>
     <mat-form-field appearance="fill">
-      <mat-label>Enter start and end date</mat-label>
+      <mat-label>{{ "dmp.steps.project.input.date" | translate }}</mat-label>
       <mat-date-range-input [formGroup]="form" [rangePicker]="picker">
         <input matStartDate formControlName="start" placeholder="Start date" />
         <input matEndDate formControlName="end" placeholder="End date" />
       </mat-date-range-input>
-      <mat-hint>DD/MM/YYYY – DD/MM/YYYY</mat-hint>
+      <mat-hint>{{ "dmp.steps.project.input.datehint" | translate }}</mat-hint>
       <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-date-range-picker #picker></mat-date-range-picker>
     </mat-form-field>
   </div>
   <app-textarea-wrapper
     [control]="description"
-    label="dmp.steps.project.input.description"></app-textarea-wrapper>
+    label="{{
+      'dmp.steps.project.input.description' | translate
+    }}"></app-textarea-wrapper>
   <button
     class="button-position-left button-color-primary"
     mat-raised-button


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Bugfix

#### What does this PR do?

Add new translation keys for en and ge

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-231
