### PR TITLE
Fix bug: Set max size for dataset columns

### DIFF
--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
@@ -41,6 +41,13 @@ tr.element-row:not(.expanded-row):active {
   display: flex;
 }
 
+.mat-column-dataset,
+.mat-column-source,
+.mat-column-description {
+  max-width: 20vw;
+  word-wrap: break-word;
+  white-space: normal;
+}
 /*th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type {
   width: 80%;
 }*/


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Bugfix

#### What does this PR do?

The dataset title, description and source table columns have a max width and the edit and delete buttons are always visible even with long dataset titles for instance.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-282
