### PR TITLE
Bug fix: Source field of Reused data can be updated

### DIFF
--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-dialog/dataset-dialog.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-dialog/dataset-dialog.component.ts
@@ -47,7 +47,7 @@ export class DatasetDialogComponent {
     this.dataset.patchValue(data.dataset);
     this.mode = data.mode ?? this.mode;
     if (data.dataset.datasetId) {
-      this.datasetId = data.dataset.datasetId;
+      this.datasetId = { ...data.dataset.datasetId };
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix

#### What does this PR do?

The field "Source" in the "Reused Data" section can be updated again. Before, the updated value did not get persisted.
In the constructor, a deep copy of the datasetId object was made, as objects from the store are by default read-only.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-283
