### PR TITLE
UI: Added navigation to dmp form sections from summary

### DIFF
--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -130,7 +130,7 @@
     </ng-container>
   </mat-step>
   <mat-step label="{{ 'dmp.steps.end.label' | translate }}">
-    <app-dmp-summary></app-dmp-summary>
+    <app-dmp-summary [stepper]="stepper"></app-dmp-summary>
   </mat-step>
 </mat-vertical-stepper>
 

--- a/libs/damap/src/lib/components/dmp/summary/summary.component.css
+++ b/libs/damap/src/lib/components/dmp/summary/summary.component.css
@@ -13,3 +13,9 @@ td.mat-mdc-cell,
 td.mat-mdc-footer-cell {
   padding: 0 10px;
 }
+
+td a {
+  color: blue;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/libs/damap/src/lib/components/dmp/summary/summary.component.html
+++ b/libs/damap/src/lib/components/dmp/summary/summary.component.html
@@ -9,7 +9,16 @@
     <th mat-header-cell *matHeaderCellDef>
       {{ "dmp.steps.summary.table.header.step" | translate }}
     </th>
-    <td mat-cell *matCellDef="let element">{{ element.step | translate }}</td>
+    <td mat-cell *matCellDef="let element; let i = index">
+      <a
+        (click)="navigateToStep(i)"
+        matTooltip="Jump to section '{{ element.step | translate }}'"
+        aria-label="Link to jump to section '{{
+          element.step | translate
+        }}' and displays a tooltip when focused or hovered over"
+        >{{ element.step | translate }}</a
+      >
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="completeness">

--- a/libs/damap/src/lib/components/dmp/summary/summary.component.ts
+++ b/libs/damap/src/lib/components/dmp/summary/summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Dmp } from '../../../domain/dmp';
 import { select, Store } from '@ngrx/store';
 import {
@@ -9,6 +9,8 @@ import { Observable } from 'rxjs';
 import { AppState } from '../../../store/states/app.state';
 import { Contributor } from '../../../domain/contributor';
 import { SummaryService } from '../../../services/summary.service';
+
+import { MatStepper } from '@angular/material/stepper';
 
 @Component({
   selector: 'app-dmp-summary',
@@ -23,6 +25,8 @@ export class SummaryComponent implements OnInit {
   dataSource;
   contact: Contributor;
 
+  @Input() stepper: MatStepper;
+
   readonly summaryTableHeaders: string[] = ['step', 'completeness', 'status'];
 
   ngOnInit(): void {
@@ -36,5 +40,9 @@ export class SummaryComponent implements OnInit {
         this.dataSource = SummaryService.dmpSummary(value);
       }
     });
+  }
+
+  navigateToStep(stepIndex: number): void {
+    this.stepper.selectedIndex = stepIndex;
   }
 }

--- a/libs/damap/src/lib/components/dmp/summary/summary.module.ts
+++ b/libs/damap/src/lib/components/dmp/summary/summary.module.ts
@@ -4,6 +4,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { SummaryComponent } from './summary.component';
 import { MatTableModule } from '@angular/material/table';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatStepperModule } from '@angular/material/stepper';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   imports: [
@@ -13,6 +15,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
     // Materials
     MatTableModule,
     MatProgressBarModule,
+    MatTooltipModule,
   ],
   declarations: [SummaryComponent],
   exports: [
@@ -23,6 +26,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
     // Materials
     MatTableModule,
     MatProgressBarModule,
+    MatStepperModule,
   ],
 })
 export class SummaryModule {}

--- a/libs/damap/src/lib/services/summary.service.ts
+++ b/libs/damap/src/lib/services/summary.service.ts
@@ -32,7 +32,8 @@ export class SummaryService {
         dmp.reusedDataKind !== DataKind.SPECIFY) ||
       !dmp.datasets.length
     ) {
-      let summary = [projectStep, peopleStep];
+      // Always display the data step, even if the data is not specified - necessary for the summary navigation
+      let summary = [projectStep, peopleStep, dataStep];
       return summary.concat(this.noDatasetsSummary());
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Feature
#### What does this PR do?

The user can now navigate to the different sections in the DMP form by clicking on the hyperlinks in the summary tab.
Furthermore, the section 3 (datasets) is always displayed in the summary to ensure the correct navigation through the sections.

#### Breaking changes

Section 3 of the DMP form is always displayed in the summary.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-256
