### PR TITLE
Global: Prevent dupplicate DOI for reused data

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -426,7 +426,8 @@
       "maxlength": "Value must not exceed {{value}} characters.",
       "pattern.currency": "Invalid input, please use the following format: 1234.56",
       "orcid": "Invalid ORCID iD.",
-      "doi": "Invalid DOI. Must be formatted as 10.1234/56789 or https://doi.org/10.1234/56789 or doi:10.1234/56789"
+      "doi": "Invalid DOI. Must be formatted as 10.1234/56789 or https://doi.org/10.1234/56789 or doi:10.1234/56789",
+      "duplicateDoi": "DOI already added."
     },
     "changes": {
       "saved": "All changes have been saved.",

--- a/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.html
@@ -16,6 +16,7 @@
   <app-doi-search
     [result]="result"
     [loading]="loading"
+    [duplicate]="duplicate"
     (termToSearch)="searchDataset($event)"
     (datasetToAdd)="add($event)"></app-doi-search>
 

--- a/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.spec.ts
@@ -1,5 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import {
+  UntypedFormArray,
+  UntypedFormControl,
+  UntypedFormGroup,
+} from '@angular/forms';
 
 import { BackendService } from '../../../../services/backend.service';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -29,6 +33,7 @@ describe('ReusedDataComponent', () => {
     component.specifyDataStep = new UntypedFormGroup({
       reusedKind: new UntypedFormControl(undefined),
     });
+    component.datasets = new UntypedFormArray([]); // Initialize the datasets FormArray
     fixture.detectChanges();
   });
 
@@ -47,5 +52,37 @@ describe('ReusedDataComponent', () => {
     expect(component.datasetToAdd.emit).toHaveBeenCalledOnceWith(
       restrictedDatasetMock,
     );
+  });
+
+  it('should remove duplicate DOI datasets', () => {
+    backendSpy.searchDataset.and.returnValue(of(restrictedDatasetMock));
+
+    expect(component.duplicate).toBeFalse();
+    expect(component.result).toBeUndefined();
+    expect(component.datasets.length).toBe(0);
+
+    component.searchDataset('doi:10.12345/12345');
+    expect(component.duplicate).toBeFalse();
+    expect(component.result).toEqual(restrictedDatasetMock);
+    expect(component.datasets.length).toBe(0);
+    component.datasets.push(
+      new UntypedFormGroup({
+        datasetId: new UntypedFormControl({ identifier: 'doi:10.12345/12345' }),
+      }),
+    );
+
+    component.searchDataset('doi:10.12345/12345');
+    expect(component.duplicate).toBeTrue();
+    expect(component.datasets.length).toBe(1);
+
+    component.searchDataset('doi:10.12345/12346');
+    expect(component.duplicate).toBeFalse();
+    expect(component.datasets.length).toBe(1);
+    component.datasets.push(
+      new UntypedFormGroup({
+        datasetId: new UntypedFormControl({ identifier: 'doi:10.12345/12346' }),
+      }),
+    );
+    expect(component.datasets.length).toBe(2);
   });
 });

--- a/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/reused-data/reused-data.component.ts
@@ -22,6 +22,7 @@ export class ReusedDataComponent
   loading: LoadingState = LoadingState.NOT_LOADED;
 
   result: Dataset;
+  duplicate = false;
 
   readonly tableHeaders: string[] = ['dataset', 'source', 'actions'];
 
@@ -64,6 +65,21 @@ export class ReusedDataComponent
   }
 
   searchDataset(term: string): void {
+    this.duplicate = false;
+    this.result = undefined;
+
+    if (this.datasets) {
+      for (let i = 0; i < this.datasets.length; i++) {
+        if (
+          this.datasets.value.at(i).datasetId &&
+          this.datasets.value.at(i).datasetId.identifier === term
+        ) {
+          this.duplicate = true;
+          return;
+        }
+      }
+    }
+
     this.searchTerms.next(term);
   }
 

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.html
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.html
@@ -30,3 +30,6 @@
 <app-error-message
   *ngIf="result === null"
   message="dmp.steps.data.specify.doi.not.found"></app-error-message>
+<app-error-message
+  *ngIf="duplicate"
+  message="form.error.duplicateDoi"></app-error-message>

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
@@ -18,6 +18,7 @@ import { LoadingState } from '../../domain/enum/loading-state.enum';
 })
 export class DoiSearchComponent implements OnChanges {
   @Input() result: Dataset = undefined;
+  @Input() duplicate: boolean = false;
   @Input() loading: LoadingState;
   @Output() termToSearch = new EventEmitter<string>();
   @Output() datasetToAdd = new EventEmitter<Dataset>();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Feature

#### What does this PR do?

Added frontend validation, check that a new added DOI is not in the datasets array, if it is, no search is run, and an error message is displayed.

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->
Related Backend Issue:

https://github.com/tuwien-csd/damap-backend/issues/239

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-254
