### PR TITLE
Global: Added acronym to manual project input

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -6,6 +6,7 @@
           "title": "Project title",
           "description": "Project description",
           "button": "Update project",
+          "acronym": "Update acronym",
           "date": "Enter start and end date",
           "datehint": "DD/MM/YYYY – DD/MM/YYYY"
         },

--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.css
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.css
@@ -1,0 +1,18 @@
+.form-row {
+  display: flex;
+}
+
+.input-60 {
+  flex: 0 0 60%;
+}
+
+.input-fill {
+  flex: 1;
+}
+
+@media (max-width: 1650px) {
+  .input-60,
+  .input-fill {
+    flex: 1;
+  }
+}

--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
@@ -1,11 +1,18 @@
 <form>
   <div class="form-row">
     <app-input-wrapper
+      class="input-60"
       [control]="title"
       label="{{
         'dmp.steps.project.input.button' | translate
       }}"></app-input-wrapper>
-    <mat-form-field appearance="fill">
+    <app-input-wrapper
+      class="input-fill"
+      [control]="acronym"
+      label="{{
+        'dmp.steps.project.input.acronym' | translate
+      }}"></app-input-wrapper>
+    <mat-form-field appearance="fill" class="input-fill">
       <mat-label>{{ "dmp.steps.project.input.date" | translate }}</mat-label>
       <mat-date-range-input [formGroup]="form" [rangePicker]="picker">
         <input matStartDate formControlName="start" placeholder="Start date" />

--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.ts
@@ -17,7 +17,7 @@ import { Project } from '../../../../domain/project';
 @Component({
   selector: 'app-manual-project-input',
   templateUrl: './manual-project-input.component.html',
-  styleUrls: [],
+  styleUrls: ['./manual-project-input.component.css'],
 })
 export class ManualProjectInputComponent implements OnChanges {
   @Input() project: Project;
@@ -32,6 +32,7 @@ export class ManualProjectInputComponent implements OnChanges {
     description: new UntypedFormControl(''),
     start: new UntypedFormControl(null),
     end: new UntypedFormControl(null),
+    acronym: new UntypedFormControl('', [Validators.maxLength(255)]),
   });
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -47,6 +48,10 @@ export class ManualProjectInputComponent implements OnChanges {
 
   get title(): UntypedFormControl {
     return this.form.get('title') as UntypedFormControl;
+  }
+
+  get acronym(): UntypedFormControl {
+    return this.form.get('acronym') as UntypedFormControl;
   }
 
   get description(): UntypedFormControl {

--- a/libs/damap/src/lib/domain/project.ts
+++ b/libs/damap/src/lib/domain/project.ts
@@ -10,4 +10,5 @@ export interface Project {
   readonly end: Date;
   readonly dmpExists: boolean;
   readonly funderSupported: boolean;
+  readonly acronym: string;
 }

--- a/libs/damap/src/lib/mocks/project-mocks.ts
+++ b/libs/damap/src/lib/mocks/project-mocks.ts
@@ -25,6 +25,7 @@ export const mockProject: Project = {
   description: '',
   dmpExists: true,
   funderSupported: true,
+  acronym: 'Acronym',
 };
 
 export const mockRecommendedProject: Project = {
@@ -50,6 +51,7 @@ export const mockRecommendedProject: Project = {
   description: '',
   dmpExists: true,
   funderSupported: false,
+  acronym: 'Acronym',
 };
 
 export const mockManualProject: Project = {
@@ -62,4 +64,5 @@ export const mockManualProject: Project = {
   description: '',
   dmpExists: undefined,
   funderSupported: false,
+  acronym: 'Acronym',
 };

--- a/libs/damap/src/lib/services/summary.service.spec.ts
+++ b/libs/damap/src/lib/services/summary.service.spec.ts
@@ -44,6 +44,7 @@ describe('SummaryService', () => {
       title: '',
       universityId: 0,
       funderSupported: false,
+      acronym: '',
     };
     let summary = SummaryService.evaluateProjectStep(null);
     expect(summary.completeness).toEqual(0);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Feature

#### What does this PR do?

Added an input field between the title and date inputs on the manual project component.

#### Dependencies

This Pull Request is strongly correlated to the backend pendant for it:
https://github.com/tuwien-csd/damap-backend/pull/241

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-161
