### PR TITLE
Bugfix: Fixed action item not shown for firefox

### DIFF
--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
@@ -53,3 +53,8 @@ tr.element-row:not(.expanded-row):active {
 }*/
 
 /* End Table Styles */
+
+.action-button-cell {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
@@ -66,7 +66,7 @@
           "dmp.steps.data.specify.table.header.actions" | translate
         }}</span>
       </th>
-      <td mat-cell *matCellDef="let element" [style]="'text-align: right'">
+      <td mat-cell *matCellDef="let element" class="action-button-cell">
         <button mat-icon-button (click)="openDatasetDialog(element)">
           <mat-icon class="material-icon-primary">edit</mat-icon>
         </button>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix

#### What does this PR do?

Fixed the second action button not getting showed in firefox (the bin icon).
Replaced "text-align: right" by "display: flex; justify-content: flex-end;"

![image](https://github.com/user-attachments/assets/b62caa7d-51b6-4196-9d4a-2b84166be3be)


### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-262
