### PR TITLE
Global: Add ability to disable internal storage

### DIFF
--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
@@ -4,7 +4,7 @@
     <mat-card
       appearance="raised"
       *ngFor="
-        let element of internalStorages
+        let element of activeStorages
           | storageFilter: storageStep?.getRawValue()
       "
       class="storage-card">
@@ -14,7 +14,7 @@
         <div mat-card-avatar>
           <mat-icon>folder_open</mat-icon>
         </div>
-        <mat-card-title>{{ element.title }}</mat-card-title>
+        <mat-card-title>{{ getStorageTitle(element) }}</mat-card-title>
       </mat-card-header>
       <ng-container *ngIf="element.url">
         <mat-card-content

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
@@ -52,4 +52,15 @@ export class StorageComponent implements OnInit {
       this.store.dispatch(loadInternalStorages());
     }
   }
+
+  get activeStorages() {
+    return this.internalStorages.filter(storage => storage.active);
+  }
+
+  public getStorageTitle(storage: InternalStorage) {
+    const translation = storage.translations.find(
+      t => t.languageCode === 'eng',
+    );
+    return translation ? translation.title : storage.translations[0].title;
+  }
 }

--- a/libs/damap/src/lib/domain/internal-storage.ts
+++ b/libs/damap/src/lib/domain/internal-storage.ts
@@ -1,11 +1,19 @@
 export interface InternalStorage {
   readonly id: number;
   readonly url: string;
-  readonly backupFrequency: string;
   readonly storageLocation: string;
   readonly backupLocation: string;
+  readonly active: boolean;
+
   // the following information comes from the translation table
+  readonly translations: InternalStorageTranslation[];
+}
+
+export interface InternalStorageTranslation {
+  readonly id: number;
   readonly languageCode: string;
   readonly title: string;
   readonly description: string;
+  readonly storageId: number;
+  readonly backupFrequency: string;
 }

--- a/libs/damap/src/lib/mocks/storage-mocks.ts
+++ b/libs/damap/src/lib/mocks/storage-mocks.ts
@@ -4,13 +4,20 @@ import { closedDatasetMock, restrictedDatasetMock } from './dataset-mocks';
 
 export const mockInternalStorage: InternalStorage = {
   id: -1,
-  backupFrequency: 'weekly',
-  backupLocation: 'AUT',
-  description: 'Internal storage mock description',
-  languageCode: 'eng',
-  storageLocation: 'AUT',
-  title: 'Internal storage mock',
   url: 'www',
+  storageLocation: 'AUT',
+  backupLocation: 'AUT',
+  active: true,
+  translations: [
+    {
+      id: -1,
+      languageCode: 'eng',
+      title: 'Internal storage mock',
+      description: 'Internal storage mock description',
+      storageId: -1,
+      backupFrequency: 'weekly',
+    },
+  ],
 };
 
 export const mockStorage: Storage = {

--- a/libs/damap/src/lib/services/backend.service.ts
+++ b/libs/damap/src/lib/services/backend.service.ts
@@ -210,7 +210,9 @@ export class BackendService {
   getInternalStorages(): Observable<InternalStorage[]> {
     const langCode = 'eng'; // TODO: Replace with template lang in the future
     return this.http
-      .get<InternalStorage[]>(`${this.backendUrl}storages/${langCode}`)
+      .get<
+        InternalStorage[]
+      >(`${this.backendUrl}storages/languageCode/${langCode}`)
       .pipe(retry(3), catchError(this.handleError('http.error.storages')));
   }
 

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -343,9 +343,17 @@ export class FormService {
 
   public addStorageToForm(storage: InternalStorage) {
     const storageFormGroup = this.createStorageFormGroup();
+
+    const translation = storage.translations.find(
+      t => t.languageCode === 'eng',
+    );
+    const title: string = translation
+      ? translation.title
+      : storage.translations[0].title;
+
     storageFormGroup.patchValue({
       internalStorageId: storage.id,
-      title: storage.title,
+      title: title,
     });
     (this.form.get('storage') as UntypedFormArray).push(storageFormGroup);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Feature:

#### What does this PR do?

Frontend implementation for:
https://github.com/tuwien-csd/damap-backend/issues/198
https://github.com/tuwien-csd/damap-backend/issues/95

Added filter Internal Storage options by active status. Refactored new InternalStorageDO (with a list of translations) from the backend.

#### Dependencies

https://github.com/tuwien-csd/damap-backend/issues/198
https://github.com/tuwien-csd/damap-backend/issues/95

Backend Pull Request:
https://github.com/tuwien-csd/damap-backend/pull/246

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge
