### PR TITLE
Link changed to redirect to the dashboard when the click in DAMAP logo in the sidebar is done 

### DIFF
--- a/apps/damap-frontend/src/app/components/layout/layout.component.html
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.html
@@ -24,7 +24,7 @@
             title="Damap"
             id="damap-logo"
             class="mat-focus-indicator"
-            [routerLink]="'/'">
+            [routerLink]="'/dashboard'">
             <span *ngIf="!isCollapsed">{{ "title" | translate }}</span>
           </a>
         </div>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Link changed to redirect to the dashboard when the click in DAMAP text in the sidebar

<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
tuwien-csd/damap-frontend/issues/306)

#### What does this PR do?

Clicking on damap redirects to /. This caused Home below to not be in blue like it should be. 
Now the redirect to redirect to /dashboard solve it.

#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-306
