### PR TITLE
DMPStepper: Make evident if a section is locked

### DIFF
--- a/apps/damap-frontend/src/styles.scss
+++ b/apps/damap-frontend/src/styles.scss
@@ -58,6 +58,9 @@
   // mat3 provides colors for error states, but not for success or warning...
   // so it is set to predefined values here
   --success-container: #e9f5d2;
+
+  --success-icon-color: #{mat.get-theme-color($app-light-theme, tertiary, 70)};
+
   --on-success-container: black;
   --warning-bg: #fff4cb;
   --background-body: #f6f6f6;

--- a/apps/damap-frontend/src/themes/custom-theme.scss
+++ b/apps/damap-frontend/src/themes/custom-theme.scss
@@ -157,6 +157,16 @@ html {
   @include mat.icon-color($app-light-theme, $color-variant: primary);
 }
 
+.material-icon-white-background-primary {
+  --mat-icon-color: white;
+  background-color: var(--primary);
+}
+
+.material-icon-white-background-success {
+  --mat-icon-color: white;
+  background-color: var(--success-icon-color);
+}
+
 .material-icon-on-secondary-container {
   --mat-icon-color: var(--on-secondary-container);
 }

--- a/libs/damap/src/lib/components/dmp/dmp.component.css
+++ b/libs/damap/src/lib/components/dmp/dmp.component.css
@@ -14,6 +14,21 @@
   margin-top: 10px;
 }
 
+.custom-icon-step {
+  border-radius: 50%;
+  padding: 4px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.number-step-icon {
+  font: var(--body-typography);
+  font-size: 1rem;
+}
+
 .verticalStepper {
   margin: 20px;
 }

--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -3,12 +3,108 @@
   #stepper
   [linear]="false"
   (selectionChange)="changeStep($event); changeStepPosition($event)">
-  <mat-step label="{{ 'dmp.steps.project.label' | translate }}">
+  <ng-template matStepperIcon="done" let-index="index">
+    <mat-icon
+      class="material-icon-white-background-success custom-icon-step"
+      *ngIf="iconsValidatorDone(index, 'check')"
+      >check</mat-icon
+    >
+    <mat-icon
+      class="material-icon-white-background-primary custom-icon-step"
+      *ngIf="iconsValidatorDone(index, 'edit')"
+      >edit</mat-icon
+    >
+    <mat-icon
+      class="custom-icon-step"
+      *ngIf="iconsValidatorDone(index, 'lock')"
+      >lock</mat-icon
+    >
+
+    <mat-icon
+      class="material-icon-white-background-success custom-icon-step"
+      *ngIf="iconsValidatorDone(index, 'text_snippet')">
+      text_snippet
+    </mat-icon>
+  </ng-template>
+
+  <ng-template matStepperIcon="edit" let-index="index">
+    <mat-icon
+      class="custom-icon-step"
+      *ngIf="iconsValidatorEdit(index, 'text_snippet')">
+      text_snippet
+    </mat-icon>
+
+    <mat-icon
+      class="material-icon-white-background-primary custom-icon-step"
+      *ngIf="iconsValidatorEdit(index, 'edit')">
+      edit
+    </mat-icon>
+
+    <mat-icon
+      class="material-icon-white-background-primary custom-icon-step"
+      *ngIf="iconsValidatorEdit(index, 'lock')"
+      >lock</mat-icon
+    >
+  </ng-template>
+
+  <ng-template matStepperIcon="number" let-index="index">
+    <mat-icon
+      class="custom-icon-step number-step-icon"
+      *ngIf="iconsValidatorNumber(index, 'number', stepper.selectedIndex)">
+      {{ index + 1 }}
+    </mat-icon>
+
+    <mat-icon
+      class="material-icon-white-background-primary custom-icon-step"
+      *ngIf="iconsValidatorNumber(index, 'edit', stepper.selectedIndex)">
+      edit
+    </mat-icon>
+
+    <mat-icon
+      class="custom-icon-step"
+      *ngIf="
+        iconsValidatorNumber(
+          index,
+          'text_snippet',
+          stepper.selectedIndex,
+          'gray'
+        )
+      ">
+      text_snippet
+    </mat-icon>
+
+    <mat-icon
+      class="material-icon-white-background-success custom-icon-step"
+      *ngIf="
+        iconsValidatorNumber(
+          index,
+          'text_snippet',
+          stepper.selectedIndex,
+          'success'
+        )
+      ">
+      text_snippet
+    </mat-icon>
+
+    <mat-icon
+      class="custom-icon-step"
+      *ngIf="iconsValidatorNumber(index, 'lock', stepper.selectedIndex)"
+      >lock</mat-icon
+    >
+  </ng-template>
+
+  <mat-step
+    label="{{ 'dmp.steps.project.label' | translate }}"
+    [completed]="
+      completenessLabel('dmp.steps.project.label')?.completeness === 100
+    ">
     <app-dmp-project
       [projectStep]="projectStep"
       (project)="changeProject($event)"></app-dmp-project>
   </mat-step>
-  <mat-step label="{{ 'dmp.steps.people.label' | translate }}">
+  <mat-step
+    label="{{ 'dmp.steps.people.label' | translate }}"
+    [completed]="completenessLabel('dmp.steps.people.label')?.completeness > 0">
     <app-dmp-people
       [config$]="config$"
       [projectMembers]="projectMembers"
@@ -20,6 +116,9 @@
   </mat-step>
   <mat-step
     label="{{ 'dmp.steps.data.specify.label' | translate }}"
+    [completed]="
+      completenessLabel('dmp.steps.data.specify.label')?.completeness > 0
+    "
     [hasError]="specifyDataStep.invalid || datasets.invalid">
     <app-dmp-specify-data
       [config$]="config$"
@@ -35,6 +134,9 @@
   </mat-step>
   <mat-step
     label="{{ 'dmp.steps.documentation.label' | translate }}"
+    [completed]="
+      completenessLabel('dmp.steps.documentation.label')?.completeness > 0
+    "
     [hasError]="docDataStep.invalid">
     <ng-container *ngIf="showStep; else noDatasets">
       <app-dmp-doc-data-quality
@@ -43,6 +145,7 @@
   </mat-step>
   <mat-step
     label="{{ 'dmp.steps.storage.label' | translate }}"
+    [completed]="completenessLabel('dmp.steps.storage.label')?.completeness > 0"
     [hasError]="
       storageStep.invalid ||
       externalStorageStep.invalid ||
@@ -78,9 +181,9 @@
       </mat-tab-group>
     </ng-container>
   </mat-step>
-
   <mat-step
     label="{{ 'dmp.steps.legal.label' | translate }}"
+    [completed]="completenessLabel('dmp.steps.legal.label')?.completeness > 0"
     [hasError]="legalEthicalStep.invalid">
     <ng-container *ngIf="showStep; else noDatasets">
       <app-dmp-legal-ethical-aspects
@@ -92,6 +195,9 @@
   </mat-step>
   <mat-step
     label="{{ 'dmp.steps.licensing.label' | translate }}"
+    [completed]="
+      completenessLabel('dmp.steps.licensing.label')?.completeness > 0
+    "
     [hasError]="datasets.invalid">
     <ng-container *ngIf="showStepIfNewDatasets; else noDatasets">
       <app-dmp-licenses [dmpForm]="dmpForm" [datasets]="datasets">
@@ -100,6 +206,9 @@
   </mat-step>
   <mat-step
     label="{{ 'dmp.steps.repositories.label' | translate }}"
+    [completed]="
+      completenessLabel('dmp.steps.repositories.label')?.completeness > 0
+    "
     [hasError]="repoStep.invalid">
     <ng-container *ngIf="showStepIfNewDatasets; else noDatasets">
       <app-dmp-repo
@@ -113,6 +222,9 @@
   </mat-step>
   <mat-step
     label="{{ 'dmp.steps.data.reuse.label' | translate }}"
+    [completed]="
+      completenessLabel('dmp.steps.data.reuse.label')?.completeness > 0
+    "
     [hasError]="reuseStep.invalid">
     <ng-container *ngIf="showStep; else noDatasets">
       <app-dmp-reuse [reuseStep]="reuseStep" [datasets]="datasets">
@@ -121,6 +233,7 @@
   </mat-step>
   <mat-step
     label="{{ 'dmp.steps.costs.label' | translate }}"
+    [completed]="completenessLabel('dmp.steps.costs.label')?.completeness > 0"
     [hasError]="costsStep.invalid">
     <ng-container *ngIf="showStep; else noDatasets">
       <app-dmp-costs
@@ -130,7 +243,9 @@
       </app-dmp-costs>
     </ng-container>
   </mat-step>
-  <mat-step label="{{ 'dmp.steps.end.label' | translate }}">
+  <mat-step
+    label="{{ 'dmp.steps.end.label' | translate }}"
+    [completed]="checkCompletenessForm() === 'completed'">
     <app-dmp-summary [stepper]="stepper"></app-dmp-summary>
   </mat-step>
 </mat-vertical-stepper>

--- a/libs/damap/src/lib/components/dmp/dmp.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.spec.ts
@@ -21,6 +21,7 @@ import { mockContributor1 } from '../../mocks/contributor-mocks';
 import { configMockData } from '../../mocks/config-service-mocks';
 import { Config } from '../../domain/config';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { selectForm } from '../../store/selectors/form.selectors';
 
 describe('DmpComponent', () => {
   let component: DmpComponent;
@@ -30,6 +31,7 @@ describe('DmpComponent', () => {
   let backendSpy: jasmine.SpyObj<BackendService>;
   let loadServiceConfigSpy;
   let feedbackSpy;
+  let storeMock;
   const initialState = {
     damap: {
       form: { dmp: null, changed: false },
@@ -49,6 +51,11 @@ describe('DmpComponent', () => {
     );
     backendSpy.getDmpById.and.returnValue(of(completeDmp));
     backendSpy.getProjectMembers.and.returnValue(of([mockContributor1]));
+
+    storeMock = {
+      pipe: jasmine.createSpy().and.returnValue(of({})),
+      dispatch: jasmine.createSpy(),
+    };
 
     TestBed.configureTestingModule({
       imports: [
@@ -75,6 +82,91 @@ describe('DmpComponent', () => {
         },
         { provide: BackendService, useValue: backendSpy },
         { provide: FeedbackService, useValue: feedbackSpy },
+        provideMockStore({
+          selectors: [
+            {
+              selector: selectForm,
+              value: {
+                id: 3,
+                title: null,
+                created: '2024-09-05T11:36:35.212Z',
+                modified: '2024-09-16T13:26:53.392Z',
+                description: null,
+                project: {
+                  id: 119,
+                  acronym: 'PROJ.HORIZON-EUROPE',
+                  universityId: 'uniProjectIdHorizonEurope0',
+                  description:
+                    'This project is funded by the EU and is recommended.',
+                  title: 'Horizon Europe Sample Project',
+                  funding: {
+                    id: 117,
+                    fundingName: null,
+                    fundingProgram: null,
+                    funderId: {
+                      identifier: '501100000780',
+                      type: 'FUNDREF',
+                    },
+                    grantId: {
+                      identifier: null,
+                      type: null,
+                    },
+                    fundingStatus: 'GRANTED',
+                  },
+                  start: '2022-01-01T00:00:00.000Z',
+                  end: '2024-12-31T00:00:00.000Z',
+                  dmpExists: false,
+                  funderSupported: true,
+                },
+                dataKind: 'SPECIFY',
+                reusedDataKind: 'UNKNOWN',
+                contributors: [],
+                noDataExplanation: null,
+                metadata: null,
+                dataGeneration: null,
+                structure: null,
+                dataQuality: [],
+                otherDataQuality: null,
+                targetAudience: null,
+                tools: null,
+                restrictedDataAccess: null,
+                personalData: true,
+                personalDataCris: true,
+                personalDataCompliance: [],
+                otherPersonalDataCompliance: null,
+                sensitiveData: true,
+                sensitiveDataCris: true,
+                sensitiveDataSecurity: [],
+                otherDataSecurityMeasures: null,
+                sensitiveDataAccess: null,
+                legalRestrictions: false,
+                legalRestrictionsCris: false,
+                legalRestrictionsDocuments: [],
+                otherLegalRestrictionsDocument: null,
+                legalRestrictionsComment: null,
+                dataRightsAndAccessControl: null,
+                humanParticipants: true,
+                humanParticipantsCris: true,
+                ethicalIssuesExist: true,
+                ethicalIssuesExistCris: true,
+                committeeReviewed: false,
+                committeeReviewedCris: false,
+                datasets: [],
+                repositories: [],
+                storage: [],
+                externalStorage: [],
+                externalStorageInfo: null,
+                restrictedAccessInfo: null,
+                closedAccessInfo: null,
+                costsExist: false,
+                costsExistCris: false,
+                costs: [],
+                documentation: null,
+                contact: null,
+              }, // Mock initial form state
+            },
+          ],
+        }),
       ],
     }).compileComponents();
   }));

--- a/libs/damap/src/lib/components/dmp/dmp.module.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.module.ts
@@ -14,6 +14,7 @@ import { HttpBackend } from '@angular/common/http';
 import { LegalEthicalAspectsModule } from './legal-ethical-aspects/legal-ethical-aspects.module';
 import { LicensesModule } from './licenses/licenses.module';
 import { MatStepperModule } from '@angular/material/stepper';
+import { MatIconModule } from '@angular/material/icon';
 import { MultiTranslateHttpLoader } from 'ngx-translate-multi-http-loader';
 import { NgModule } from '@angular/core';
 import { PeopleModule } from './people/people.module';
@@ -71,6 +72,7 @@ export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
 
     // Materials
     MatStepperModule,
+    MatIconModule,
     DmpActionsModule,
   ],
   declarations: [DmpComponent],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
Feature
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Set the icon for when a step is blocked and requires action. 
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
https://github.com/tuwien-csd/damap-frontend/issues/35

#### What does this PR do?
Change the icons for steps in the stepper on dmpComponent where an action is required. For example, step 4 requires a dataset that was previously registered in step 3. 

<!-- Changes introduced by this PR - what happened before, what happens now -->
Before
<img width="953" alt="image" src="https://github.com/user-attachments/assets/02fd4872-b8b4-4cc6-8f61-9ee9060ef59b">

Now the icon when a step is blocked is a lock, and when a step is even empty, the step color remains gray. 

<img width="950" alt="image" src="https://github.com/user-attachments/assets/33695c6b-334f-48e1-8b7a-a89b16d83aaf">

<img width="952" alt="image" src="https://github.com/user-attachments/assets/a5f9a0a2-6571-4852-bbce-8116b2869d9e">

![image](https://github.com/user-attachments/assets/402468ec-682b-4311-b90b-5cfa37f12c59)





#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->


#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-35