### PR TITLE
Gk/236 add admin only UI to work with internal storages

### DIFF
--- a/apps/damap-frontend/src/app/app.module.ts
+++ b/apps/damap-frontend/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { APP_INITIALIZER, NgModule } from '@angular/core';
-import { AuthGuard, EnvBannerModule } from '@damap/core';
+import { EnvBannerModule, AuthGuard } from '@damap/core';
 import { HttpBackend, HttpClientModule } from '@angular/common/http';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
@@ -28,7 +28,9 @@ export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
     '/assets/damap-core/i18n/plans/',
     '/assets/damap-core/i18n/http/',
     '/assets/damap-core/i18n/gdpr/',
+    '/assets/damap-core/i18n/admin/',
     '/assets/damap-core/i18n/',
+    '/assets/damap-core/i18n/templates/',
     '/assets/i18n/',
   ]);
 }

--- a/apps/damap-frontend/src/app/components/layout/layout.component.html
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.html
@@ -71,6 +71,17 @@
             "layout.menu.plans" | translate
           }}</span>
         </a>
+        <a
+          *ngIf="isAdmin()"
+          mat-list-item
+          [routerLink]="'/admin'"
+          routerLinkActive="active-icon material-icon-primary"
+          [routerLinkActiveOptions]="{ exact: true }">
+          <mat-icon class="menu-icon-size outline">shield_person</mat-icon>
+          <span *ngIf="!isCollapsed" class="menu-icon-text">{{
+            "layout.menu.admin" | translate
+          }}</span>
+        </a>
       </div>
       <mat-divider></mat-divider>
     </mat-nav-list>

--- a/apps/damap-frontend/src/app/components/layout/layout.component.spec.ts
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.spec.ts
@@ -42,10 +42,15 @@ describe('LayoutComponent', () => {
         .and.returnValue('mock-url'), // Mock serializeUrl if needed
     };
 
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaXNBZG1pbiI6dHJ1ZX0.dummySignature';
+
     const oauthSpy = jasmine.createSpyObj('OAuthService', [
       'getIdentityClaims',
+      'getAccessToken',
     ]);
     oauthSpy.getIdentityClaims.and.returnValue({ name: 'name' });
+    oauthSpy.getAccessToken.and.returnValue(mockToken);
 
     const configSpy = jasmine.createSpyObj('ConfigService', ['getEnvironment']);
     configSpy.getEnvironment.and.returnValue('DEV');

--- a/apps/damap-frontend/src/app/components/layout/layout.component.ts
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.ts
@@ -103,6 +103,10 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
    * step changes of the DMP component.
    * @return {void}
    */
+  public isAdmin(): boolean {
+    return this.auth.isAdmin();
+  }
+
   private handleRouteChange(): void {
     // unsubscribe, if subscribed before. will subscribe again when redirecting to DMP component
     this.dataInfoService?.unsubscribe();

--- a/apps/damap-frontend/src/assets/i18n/layout/de.json
+++ b/apps/damap-frontend/src/assets/i18n/layout/de.json
@@ -4,6 +4,7 @@
     "menu": {
       "home": "Startseite",
       "plans": "DMPs",
+      "admin": "Admin",
       "mobile": {
         "open": "Seitennavigation öffnen",
         "close": "Seitennavigation schließen"

--- a/apps/damap-frontend/src/assets/i18n/layout/en.json
+++ b/apps/damap-frontend/src/assets/i18n/layout/en.json
@@ -4,6 +4,7 @@
     "menu": {
       "home": "Home",
       "plans": "DMPs",
+      "admin": "Admin",
       "greeting": "Hi",
       "titleDashboard": " let's get started!",
       "section": "Welcome to DAMAP, a service that helps you create a Data Management Plan (DMP) for your project.",

--- a/libs/damap/src/assets/i18n/admin/de.json
+++ b/libs/damap/src/assets/i18n/admin/de.json
@@ -1,0 +1,70 @@
+{
+  "admin": {
+    "title": "Admin Seite",
+    "internal-storage": "Interne Speicher",
+    "internal-storage-translations": "Übersetzungen für: ",
+    "internal-storage-translations-no-selected": "Übersetzungen",
+    "reset-selection": "Auswahl zurücksetzen",
+    "translation-info": "Um die Übersetzungen für einen bestimmten internen Speicher zu sehen, wählen Sie bitte den internen Speicher aus der Liste im Aktionsmenü und die Option 'Übersetzungen'.",
+    "table": {
+      "header": {
+        "url": "URL",
+        "storageLocation": "Speicher Location",
+        "backupLocation": "Backup Location",
+        "active": "Aktiv",
+        "action": "Aktionen",
+        "langugageCode": "Sprachcode",
+        "title": "Titel",
+        "description": "Beschreibung",
+        "backupFrequency": "Backup Häufigkeit"
+      },
+      "action": {
+        "delete": "Löschen",
+        "deactivate": "Deaktivieren",
+        "activate": "Aktivieren",
+        "edit": "Bearbeiten",
+        "translation": "Übersetzungen"
+      },
+      "empty": "Keine Daten verfügbar",
+      "no-selected": "Kein interner Speicher ausgewählt"
+    },
+    "create": {
+      "storage": "Neuen internen Speicher hinzufügen",
+      "translation": "Neue Übersetzung hinzufügen"
+    },
+    "dialog": {
+      "internal-storage": {
+        "edit": "Internen Speicher bearbeiten",
+        "add": "Internen Speicher hinzufügen",
+        "button": {
+          "cancel": "Abbrechen",
+          "add": "Hinzufügen",
+          "update": "Aktualisieren"
+        },
+        "captions": {
+          "url": "URL",
+          "storageLocation": "Speicher Location",
+          "backupLocation": "Backup Location",
+          "active": "Ist der interne Speicher aktiv?"
+        }
+      },
+      "internal-storage-translation": {
+        "edit": "Übersetzung bearbeiten",
+        "add": "Übersetzung hinzufügen",
+        "button": {
+          "cancel": "Abbrechen",
+          "add": "Hinzufügen",
+          "update": "Aktualisieren"
+        },
+        "captions": {
+          "title": "Titel",
+          "description": "Beschreibung",
+          "languageCode": "Sprachcode",
+          "backupFrequency": "Backup Häufigkeit",
+          "eng": "Englisch",
+          "deu": "Deutsch"
+        }
+      }
+    }
+  }
+}

--- a/libs/damap/src/assets/i18n/admin/en.json
+++ b/libs/damap/src/assets/i18n/admin/en.json
@@ -1,0 +1,70 @@
+{
+  "admin": {
+    "title": "Admin page",
+    "internal-storage": "Internal Storage",
+    "internal-storage-translations": "Translations for: ",
+    "internal-storage-translations-no-selected": "Translations",
+    "reset-selection": "Reset selection",
+    "translation-info": "In order to see the translations for a specific internal storage, please select the internal storage from the list in the actions menu, and the option 'Translations'.",
+    "table": {
+      "header": {
+        "url": "URL",
+        "storageLocation": "Storage Location",
+        "backupLocation": "Backup Location",
+        "active": "Active",
+        "action": "Actions",
+        "langugageCode": "Language Code",
+        "title": "Title",
+        "description": "Description",
+        "backupFrequency": "Backup Frequency"
+      },
+      "action": {
+        "delete": "Delete",
+        "deactivate": "Deactivate",
+        "activate": "Activate",
+        "edit": "Edit",
+        "translation": "Translations"
+      },
+      "empty": "No data available",
+      "no-selected": "No internal storage selected"
+    },
+    "create": {
+      "storage": "Add new internal storage",
+      "translation": "Add new translation"
+    },
+    "dialog": {
+      "internal-storage": {
+        "edit": "Edit internal storage",
+        "add": "Add internal storage",
+        "button": {
+          "cancel": "Cancel",
+          "add": "Add",
+          "update": "Update"
+        },
+        "captions": {
+          "url": "URL",
+          "storageLocation": "Storage Location",
+          "backupLocation": "Backup Location",
+          "active": "Internal storage is active?"
+        }
+      },
+      "internal-storage-translation": {
+        "edit": "Edit translation",
+        "add": "Add translation",
+        "button": {
+          "cancel": "Cancel",
+          "add": "Add",
+          "update": "Update"
+        },
+        "captions": {
+          "title": "Title",
+          "description": "Description",
+          "languageCode": "Language Code",
+          "backupFrequency": "Backup Frequency",
+          "eng": "English",
+          "deu": "German"
+        }
+      }
+    }
+  }
+}

--- a/libs/damap/src/assets/i18n/en.json
+++ b/libs/damap/src/assets/i18n/en.json
@@ -33,7 +33,11 @@
     },
     "delete": {
       "title": "Please note:",
-      "content": "You are about to delete this DMP. This action cannot be undone. Are you sure you want to proceed?",
+      "content": {
+        "dmp": "You are about to delete this DMP. This action cannot be undone. Are you sure you want to proceed?",
+        "storage": "You are about to delete this storage. This action cannot be undone. Are you sure you want to proceed?",
+        "storageTranslation": "You are about to delete this storage translation. This action cannot be undone. Are you sure you want to proceed?"
+      },
       "button": "Delete",
       "cancel": "Cancel"
     }

--- a/libs/damap/src/assets/i18n/http/en.json
+++ b/libs/damap/src/assets/i18n/http/en.json
@@ -31,6 +31,10 @@
         "delete": "Failed to delete DMP. "
       },
       "storages": "Failed to load storages. ",
+      "storageErrors": {
+        "stillInUse": "Storage is used in at least one DMP and therefore cannot be deleted.",
+        "lastTranslation": "The last translation for a given storage cannot be deleted."
+      },
       "versions": {
         "load": "Failed to load DMP versions. ",
         "save": "Failed to save DMP version. ",
@@ -42,6 +46,18 @@
         "load": "Failed to load access information. ",
         "save": "Failed to update access. ",
         "delete": "Failed to remove access. "
+      }
+    },
+    "success": {
+      "storage": {
+        "translations": {
+          "add": "Storage translation created successfully.",
+          "edit": "Storage translation updated successfully.",
+          "delete": "Storage translation deleted successfully."
+        },
+        "delete": "Storage deleted successfully.",
+        "add": "Storage created successfully.",
+        "edit": "Storage updated successfully."
       }
     }
   }

--- a/libs/damap/src/lib/components/admin/admin.component.css
+++ b/libs/damap/src/lib/components/admin/admin.component.css
@@ -1,0 +1,14 @@
+.selected-storage {
+  word-wrap: break-word;
+  white-space: normal;
+}
+
+div#content {
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-bottom: 50px;
+}
+
+.content-max-width {
+  max-width: 1440px;
+}

--- a/libs/damap/src/lib/components/admin/admin.component.html
+++ b/libs/damap/src/lib/components/admin/admin.component.html
@@ -1,0 +1,49 @@
+<div id="content" class="content-max-width">
+  <h1 translate>admin.title</h1>
+  <h2 translate>admin.internal-storage</h2>
+  <button
+    class="button-position button-color-primary"
+    mat-raised-button
+    (click)="openStorageDialog()">
+    <mat-icon>add</mat-icon>
+    {{ "admin.create.storage" | translate }}
+  </button>
+  <damap-internal-storage-table
+    [internalStorages]="internalStorages"
+    (selectInternalStorage)="
+      selectStorage($event)
+    "></damap-internal-storage-table>
+  <h2 class="selected-storage">
+    {{
+      selectedInternalStorageUrl !== null
+        ? ("admin.internal-storage-translations" | translate)
+        : ("admin.internal-storage-translations-no-selected" | translate)
+    }}
+    {{ selectedInternalStorageUrl }}
+  </h2>
+  <div *ngIf="selectedInternalStorageId === null">
+    <p>
+      {{ "admin.translation-info" | translate }}
+    </p>
+  </div>
+  <div *ngIf="selectedInternalStorageId !== null">
+    <button
+      class="button-position button-color-primary"
+      mat-raised-button
+      (click)="openTranslationDialog()">
+      <mat-icon>add</mat-icon>
+      {{ "admin.create.translation" | translate }}
+    </button>
+    <button
+      class="button-position button-color-primary"
+      mat-raised-button
+      (click)="resetStorageSelection()">
+      {{ "admin.reset-selection" | translate }}
+    </button>
+    <damap-internal-storage-translation-table
+      [internalStorageTranslations]="internalStorageTranslations"
+      [selectedInternalStorageId]="
+        selectedInternalStorageId
+      "></damap-internal-storage-translation-table>
+  </div>
+</div>

--- a/libs/damap/src/lib/components/admin/admin.component.ts
+++ b/libs/damap/src/lib/components/admin/admin.component.ts
@@ -1,0 +1,137 @@
+import { Component, OnInit } from '@angular/core';
+import { BackendService } from '../../services/backend.service';
+import { AuthService } from '../../auth/auth.service';
+import {
+  InternalStorage,
+  InternalStorageTranslation,
+} from '../../domain/internal-storage';
+import { MatDialog } from '@angular/material/dialog';
+import { InternalStorageDialogComponent } from './internal-storage-dialog/internal-storage-dialog.component';
+import { FeedbackService } from '../../services/feedback.service';
+import { Router } from '@angular/router';
+import { InternalStorageTranslationDialogComponent } from './internal-storage-translation-dialog/internal-storage-translation-dialog.component';
+import { firstValueFrom } from 'rxjs';
+
+@Component({
+  selector: 'damap-admin',
+  templateUrl: './admin.component.html',
+  styleUrl: './admin.component.css',
+})
+export class AdminComponent implements OnInit {
+  constructor(
+    private backendService: BackendService,
+    private dialog: MatDialog,
+    private feedbackService: FeedbackService,
+  ) {}
+
+  showOnlyActive = true;
+  internalStorages: InternalStorage[] = [];
+  internalStorageTranslations: InternalStorageTranslation[] = [];
+  selectedInternalStorageId: number;
+  selectedInternalStorageUrl: string;
+
+  ngOnInit(): void {
+    this.selectedInternalStorageId = null;
+    this.selectedInternalStorageUrl = null;
+
+    this.backendService.searchInternalStorage({}).subscribe(data => {
+      this.internalStorages = data.items;
+    });
+  }
+
+  async openStorageDialog() {
+    const dialogRef = this.dialog.open(InternalStorageDialogComponent, {
+      width: '75%',
+      maxWidth: '800px',
+      data: { mode: 'add' },
+    });
+
+    const storage = await firstValueFrom(dialogRef.afterClosed());
+    if (storage) {
+      this.backendService.createInternalStorage(storage).subscribe(
+        () => {
+          this.feedbackService.success('http.success.storage.add');
+          this.backendService.searchInternalStorage({}).subscribe(data => {
+            this.internalStorages = data.items;
+            this.selectStorage(data.items.find(s => s.url === storage.url).id);
+          });
+        },
+        error => {
+          if (error.error?.message) {
+            this.feedbackService.error(error.error.message);
+          } else {
+            this.feedbackService.error(error.message);
+          }
+        },
+      );
+    }
+  }
+
+  openTranslationDialog() {
+    const dialogRef = this.dialog.open(
+      InternalStorageTranslationDialogComponent,
+      {
+        width: '75%',
+        maxWidth: '800px',
+        data: { mode: 'add', storageId: this.selectedInternalStorageId },
+      },
+    );
+
+    dialogRef.afterClosed().subscribe(translation => {
+      if (translation) {
+        this.backendService
+          .createInternalStorageTranslation(translation)
+          .subscribe(
+            () => {
+              this.backendService
+                .getAllInternalStorageTranslationsForStorage(
+                  this.selectedInternalStorageId,
+                )
+                .subscribe(data => {
+                  this.internalStorageTranslations = data;
+                  this.feedbackService.success(
+                    'http.success.storage.translations.add',
+                  );
+                });
+            },
+            error => {
+              if (error.error?.message) {
+                this.feedbackService.error(error.error.message);
+              } else {
+                this.feedbackService.error(error.message);
+              }
+            },
+          );
+      }
+    });
+  }
+
+  selectStorage(storageId: number) {
+    if (storageId === null) {
+      this.resetStorageSelection();
+      return;
+    }
+    this.backendService.getInternalStorage(storageId).subscribe(storage => {
+      this.internalStorages = this.internalStorages.map(s =>
+        s.id === storageId ? storage : s,
+      );
+      this.backendService
+        .getAllInternalStorageTranslationsForStorage(storageId)
+        .subscribe(data => {
+          this.selectedInternalStorageId = storageId;
+          this.internalStorageTranslations = data;
+          this.selectedInternalStorageUrl = storage.url;
+        });
+    });
+  }
+
+  resetStorageSelection() {
+    this.selectedInternalStorageId = null;
+    this.internalStorageTranslations = [];
+    this.selectedInternalStorageUrl = null;
+
+    this.backendService.searchInternalStorage({}).subscribe(data => {
+      this.internalStorages = data.items;
+    });
+  }
+}

--- a/libs/damap/src/lib/components/admin/admin.module.ts
+++ b/libs/damap/src/lib/components/admin/admin.module.ts
@@ -1,0 +1,71 @@
+import { CommonModule } from '@angular/common';
+import { DmpTableModule } from '../../widgets/dmp-table/dmp-table.module';
+import { ErrorMessageModule } from '../../widgets/error-message/error-message.module';
+import { ExportWarningModule } from '../../widgets/export-warning-dialog/export-warning.module';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { AdminComponent } from './admin.component';
+import { InternalStorageTableModule } from '../../widgets/internal-storage-table/internal-storage-table.module';
+import { InternalStorageDialogComponent } from './internal-storage-dialog/internal-storage-dialog.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared.module';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { InternalStoragaTranslationTableModule } from '../../widgets/internal-storage-translation-table/internal-storage-translation-table.module';
+import { InternalStorageTranslationDialogComponent } from './internal-storage-translation-dialog/internal-storage-translation-dialog.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TranslateModule,
+    RouterModule,
+    DmpTableModule,
+    ErrorMessageModule,
+    ExportWarningModule,
+    InternalStorageTableModule,
+    InternalStoragaTranslationTableModule,
+    ReactiveFormsModule,
+    // Materials
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    MatSortModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSelectModule,
+    SharedModule,
+    MatCheckboxModule,
+  ],
+  declarations: [
+    AdminComponent,
+    InternalStorageDialogComponent,
+    InternalStorageTranslationDialogComponent,
+  ],
+  exports: [
+    CommonModule,
+    TranslateModule,
+    RouterModule,
+    DmpTableModule,
+    ErrorMessageModule,
+    AdminComponent,
+    ExportWarningModule,
+    InternalStorageTableModule,
+
+    // Materials
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    MatSortModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSelectModule,
+  ],
+})
+export class AdminModule {}

--- a/libs/damap/src/lib/components/admin/internal-storage-dialog/internal-storage-dialog.component.css
+++ b/libs/damap/src/lib/components/admin/internal-storage-dialog/internal-storage-dialog.component.css
@@ -1,0 +1,5 @@
+.dialogRow {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}

--- a/libs/damap/src/lib/components/admin/internal-storage-dialog/internal-storage-dialog.component.html
+++ b/libs/damap/src/lib/components/admin/internal-storage-dialog/internal-storage-dialog.component.html
@@ -1,0 +1,97 @@
+<h1 mat-dialog-title>
+  <ng-container *ngIf="mode === 'edit'; else add">{{
+    "admin.dialog.internal-storage.edit" | translate
+  }}</ng-container>
+  <ng-template #add>{{
+    "admin.dialog.internal-storage.add" | translate
+  }}</ng-template>
+</h1>
+
+<mat-dialog-content id="datasetDialog">
+  <div [formGroup]="storage">
+    <app-input-wrapper
+      [label]="'admin.dialog.internal-storage.captions.url' | translate"
+      [control]="url"></app-input-wrapper>
+    <app-input-wrapper
+      [label]="
+        'admin.dialog.internal-storage.captions.storageLocation' | translate
+      "
+      [control]="storageLocation"></app-input-wrapper>
+    <app-input-wrapper
+      [label]="
+        'admin.dialog.internal-storage.captions.backupLocation' | translate
+      "
+      [control]="backupLocation"></app-input-wrapper>
+    <mat-checkbox formControlName="active">
+      {{ "admin.dialog.internal-storage.captions.active" | translate }}
+    </mat-checkbox>
+    <div *ngIf="mode === 'add'">
+      <div [formGroup]="storageTranslation">
+        <hr />
+
+        <div class="dialogRow">
+          <mat-form-field>
+            <mat-label>{{
+              "admin.dialog.internal-storage-translation.captions.languageCode"
+                | translate
+            }}</mat-label>
+            <mat-select formControlName="languageCode" required>
+              <mat-option [value]="'eng'">
+                {{
+                  "admin.dialog.internal-storage-translation.captions.eng"
+                    | translate
+                }}
+              </mat-option>
+              <mat-option [value]="'deu'">
+                {{
+                  "admin.dialog.internal-storage-translation.captions.deu"
+                    | translate
+                }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <app-input-wrapper
+          [label]="
+            'admin.dialog.internal-storage-translation.captions.title'
+              | translate
+          "
+          [control]="title"></app-input-wrapper>
+
+        <app-textarea-wrapper
+          [label]="
+            'admin.dialog.internal-storage-translation.captions.description'
+              | translate
+          "
+          [control]="description"
+          [maxLength]="4000"></app-textarea-wrapper>
+
+        <app-input-wrapper
+          [label]="
+            'admin.dialog.internal-storage-translation.captions.backupFrequency'
+              | translate
+          "
+          [control]="backupFrequency"></app-input-wrapper>
+      </div>
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">
+    {{ "admin.dialog.internal-storage.button.cancel" | translate }}
+  </button>
+  <button
+    (click)="onDialogClose()"
+    mat-raised-button
+    class="button-color-primary"
+    [disabled]="isDisabled()">
+    <ng-container *ngIf="mode === 'edit'">{{
+      "admin.dialog.internal-storage.button.update" | translate
+    }}</ng-container>
+    <ng-container *ngIf="mode === 'add'">{{
+      "admin.dialog.internal-storage.button.add" | translate
+    }}</ng-container>
+  </button>
+</mat-dialog-actions>

--- a/libs/damap/src/lib/components/admin/internal-storage-dialog/internal-storage-dialog.component.ts
+++ b/libs/damap/src/lib/components/admin/internal-storage-dialog/internal-storage-dialog.component.ts
@@ -1,0 +1,91 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormControl,
+  UntypedFormControl,
+  UntypedFormGroup,
+} from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { InternalStorage } from '../../../domain/internal-storage';
+import { FormService } from '../../../services/form.service';
+
+@Component({
+  selector: 'damap-internal-storage-dialog',
+  templateUrl: './internal-storage-dialog.component.html',
+  styleUrl: './internal-storage-dialog.component.css',
+})
+export class InternalStorageDialogComponent {
+  public mode = 'add';
+  storage: UntypedFormGroup;
+  storageTranslation: UntypedFormGroup;
+
+  constructor(
+    public dialogRef: MatDialogRef<InternalStorageDialogComponent>,
+    private formService: FormService,
+    @Inject(MAT_DIALOG_DATA)
+    public data: { storage: InternalStorage; mode: string },
+  ) {
+    this.storage = this.formService.createInternalStorageFormGroup();
+
+    if (data.storage) {
+      this.storage.patchValue(data.storage);
+    }
+
+    this.storageTranslation =
+      this.formService.createInternalStorageTranslationFormGroup();
+    this.mode = data.mode ?? this.mode;
+  }
+
+  get url(): UntypedFormControl {
+    return this.storage.get('url') as UntypedFormControl;
+  }
+
+  get backupLocation(): UntypedFormControl {
+    return this.storage.get('backupLocation') as UntypedFormControl;
+  }
+
+  get storageLocation(): UntypedFormControl {
+    return this.storage.get('storageLocation') as UntypedFormControl;
+  }
+
+  get active(): UntypedFormControl {
+    return this.storage.get('active') as UntypedFormControl;
+  }
+
+  get languageCode(): UntypedFormControl {
+    return this.storageTranslation.get('languageCode') as UntypedFormControl;
+  }
+
+  get title(): UntypedFormControl {
+    return this.storageTranslation.get('title') as UntypedFormControl;
+  }
+
+  get description(): UntypedFormControl {
+    return this.storageTranslation.get('description') as UntypedFormControl;
+  }
+
+  get backupFrequency(): UntypedFormControl {
+    return this.storageTranslation.get('backupFrequency') as UntypedFormControl;
+  }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  onDialogClose() {
+    let newStorage = this.storage.value;
+    if (this.mode === 'add') {
+      newStorage.translations = [this.storageTranslation.value];
+    }
+
+    this.dialogRef.close(newStorage);
+  }
+
+  isDisabled(): boolean {
+    return (
+      (this.mode == 'add' &&
+        (this.storage.invalid || this.storageTranslation.invalid)) ||
+      (this.mode == 'edit' && this.storage.invalid)
+    );
+  }
+}

--- a/libs/damap/src/lib/components/admin/internal-storage-translation-dialog/internal-storage-translation-dialog.component.css
+++ b/libs/damap/src/lib/components/admin/internal-storage-translation-dialog/internal-storage-translation-dialog.component.css
@@ -1,0 +1,5 @@
+.dialogRow {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}

--- a/libs/damap/src/lib/components/admin/internal-storage-translation-dialog/internal-storage-translation-dialog.component.html
+++ b/libs/damap/src/lib/components/admin/internal-storage-translation-dialog/internal-storage-translation-dialog.component.html
@@ -1,0 +1,76 @@
+<h1 mat-dialog-title>
+  <ng-container *ngIf="mode === 'edit'; else add">{{
+    "admin.dialog.internal-storage-translation.edit" | translate
+  }}</ng-container>
+  <ng-template #add>{{
+    "admin.dialog.internal-storage-translation.add" | translate
+  }}</ng-template>
+</h1>
+
+<mat-dialog-content id="datasetDialog">
+  <div [formGroup]="storageTranslation">
+    <hr />
+
+    <div class="dialogRow">
+      <mat-form-field>
+        <mat-label>{{
+          "admin.dialog.internal-storage-translation.captions.languageCode"
+            | translate
+        }}</mat-label>
+        <mat-select formControlName="languageCode" required>
+          <mat-option [value]="'eng'">
+            {{
+              "admin.dialog.internal-storage-translation.captions.eng"
+                | translate
+            }}
+          </mat-option>
+          <mat-option [value]="'deu'">
+            {{
+              "admin.dialog.internal-storage-translation.captions.deu"
+                | translate
+            }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <app-input-wrapper
+      [label]="
+        'admin.dialog.internal-storage-translation.captions.title' | translate
+      "
+      [control]="title"></app-input-wrapper>
+
+    <app-textarea-wrapper
+      [label]="
+        'admin.dialog.internal-storage-translation.captions.description'
+          | translate
+      "
+      [control]="description"
+      [maxLength]="4000"></app-textarea-wrapper>
+
+    <app-input-wrapper
+      [label]="
+        'admin.dialog.internal-storage-translation.captions.backupFrequency'
+          | translate
+      "
+      [control]="backupFrequency"></app-input-wrapper>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">
+    {{ "admin.dialog.internal-storage-translation.button.cancel" | translate }}
+  </button>
+  <button
+    (click)="onDialogClose()"
+    mat-raised-button
+    class="button-color-primary"
+    [disabled]="storageTranslation.invalid">
+    <ng-container *ngIf="mode === 'edit'">{{
+      "admin.dialog.internal-storage-translation.button.update" | translate
+    }}</ng-container>
+    <ng-container *ngIf="mode === 'add'">{{
+      "admin.dialog.internal-storage-translation.button.add" | translate
+    }}</ng-container>
+  </button>
+</mat-dialog-actions>

--- a/libs/damap/src/lib/components/admin/internal-storage-translation-dialog/internal-storage-translation-dialog.component.ts
+++ b/libs/damap/src/lib/components/admin/internal-storage-translation-dialog/internal-storage-translation-dialog.component.ts
@@ -1,0 +1,64 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormService } from '../../../services/form.service';
+import { InternalStorageTranslation } from '../../../domain/internal-storage';
+
+@Component({
+  selector: 'internal-storage-translation-dialog',
+  templateUrl: './internal-storage-translation-dialog.component.html',
+  styleUrl: './internal-storage-translation-dialog.component.css',
+})
+export class InternalStorageTranslationDialogComponent {
+  public mode = 'add';
+  storageTranslation: UntypedFormGroup;
+
+  constructor(
+    public dialogRef: MatDialogRef<InternalStorageTranslationDialogComponent>,
+    private formService: FormService,
+    @Inject(MAT_DIALOG_DATA)
+    public data: {
+      storageId: number;
+      translation: InternalStorageTranslation;
+      mode: string;
+    },
+  ) {
+    this.storageTranslation =
+      this.formService.createInternalStorageTranslationFormGroup();
+
+    if (data.translation) {
+      this.storageTranslation.patchValue(data.translation);
+    }
+
+    this.storageTranslation.get('storageId').setValue(data.storageId);
+
+    this.mode = data.mode ?? this.mode;
+  }
+
+  get languageCode(): UntypedFormControl {
+    return this.storageTranslation.get('languageCode') as UntypedFormControl;
+  }
+
+  get title(): UntypedFormControl {
+    return this.storageTranslation.get('title') as UntypedFormControl;
+  }
+
+  get description(): UntypedFormControl {
+    return this.storageTranslation.get('description') as UntypedFormControl;
+  }
+
+  get backupFrequency(): UntypedFormControl {
+    return this.storageTranslation.get('backupFrequency') as UntypedFormControl;
+  }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  onDialogClose() {
+    let newTranslation = this.storageTranslation.value;
+    newTranslation.id = this.data.translation?.id;
+    this.dialogRef.close(newTranslation);
+  }
+}

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
@@ -4,7 +4,7 @@
     <mat-card
       appearance="raised"
       *ngFor="
-        let element of internalStorages
+        let element of activeStorages
           | storageFilter: storageStep?.getRawValue()
       "
       class="storage-card">
@@ -14,7 +14,7 @@
         <div mat-card-avatar>
           <mat-icon>folder_open</mat-icon>
         </div>
-        <mat-card-title>{{ element.title }}</mat-card-title>
+        <mat-card-title>{{ getStorageTitle(element) }}</mat-card-title>
       </mat-card-header>
       <ng-container *ngIf="element.url">
         <mat-card-content

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
@@ -48,8 +48,19 @@ export class StorageComponent implements OnInit {
   }
 
   private getInternalStorages() {
-    if (this.internalStoragesLoaded !== LoadingState.LOADED) {
-      this.store.dispatch(loadInternalStorages());
-    }
+    this.store.dispatch(loadInternalStorages());
+  }
+
+  get activeStorages() {
+    return this.internalStorages.filter(
+      storage => storage.active && storage.translations.length > 0,
+    );
+  }
+
+  public getStorageTitle(storage: InternalStorage) {
+    const translation = storage.translations.find(
+      t => t.languageCode === 'eng',
+    );
+    return translation ? translation.title : storage.translations[0].title;
   }
 }

--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
@@ -43,6 +43,7 @@ tr.element-row:not(.expanded-row):active {
 
 .mat-column-dataset,
 .mat-column-source,
+.mat-column-fileFormat,
 .mat-column-description {
   max-width: 20vw;
   word-wrap: break-word;

--- a/libs/damap/src/lib/damap.module.ts
+++ b/libs/damap/src/lib/damap.module.ts
@@ -9,6 +9,9 @@ import { TranslateModule } from '@ngx-translate/core';
 import { DamapStoreModule } from './store/damap-store.module';
 import { APP_ENV } from './constants';
 import { GdprComponent } from './components/gdpr/gdpr.component';
+import { AdminComponent } from './components/admin/admin.component';
+import { AdminModule } from './components/admin/admin.module';
+import { AdminGuard } from './guards/admin.guard';
 
 export const DAMAP_ROUTES: Route[] = [
   { path: '', component: DashboardComponent },
@@ -20,9 +23,10 @@ export const DAMAP_ROUTES: Route[] = [
       import('./components/dmp/dmp.module').then(m => m.DmpModule),
   },
   { path: 'gdpr', component: GdprComponent },
+  { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] },
 ];
 
-const MODULES = [DashboardModule, PlansModule];
+const MODULES = [DashboardModule, PlansModule, AdminModule];
 
 @NgModule({
   imports: [

--- a/libs/damap/src/lib/domain/internal-storage.ts
+++ b/libs/damap/src/lib/domain/internal-storage.ts
@@ -1,11 +1,19 @@
 export interface InternalStorage {
   readonly id: number;
   readonly url: string;
-  readonly backupFrequency: string;
   readonly storageLocation: string;
   readonly backupLocation: string;
+  readonly active: boolean;
+
   // the following information comes from the translation table
+  readonly translations: InternalStorageTranslation[];
+}
+
+export interface InternalStorageTranslation {
+  readonly id: number;
   readonly languageCode: string;
   readonly title: string;
   readonly description: string;
+  readonly storageId: number;
+  readonly backupFrequency: string;
 }

--- a/libs/damap/src/lib/guards/admin.guard.ts
+++ b/libs/damap/src/lib/guards/admin.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminGuard implements CanActivate {
+  constructor(
+    private authService: AuthService,
+    private router: Router,
+  ) {}
+
+  canActivate(): boolean {
+    if (this.authService.isAdmin()) {
+      return true;
+    } else {
+      this.router.navigate(['/dashboard']);
+      return false;
+    }
+  }
+}

--- a/libs/damap/src/lib/mocks/storage-mocks.ts
+++ b/libs/damap/src/lib/mocks/storage-mocks.ts
@@ -1,16 +1,24 @@
 import { InternalStorage } from '../domain/internal-storage';
+import { SearchResult } from '../domain/search/search-result';
 import { Storage } from '../domain/storage';
 import { closedDatasetMock, restrictedDatasetMock } from './dataset-mocks';
 
 export const mockInternalStorage: InternalStorage = {
   id: -1,
-  backupFrequency: 'weekly',
-  backupLocation: 'AUT',
-  description: 'Internal storage mock description',
-  languageCode: 'eng',
-  storageLocation: 'AUT',
-  title: 'Internal storage mock',
   url: 'www',
+  storageLocation: 'AUT',
+  backupLocation: 'AUT',
+  active: true,
+  translations: [
+    {
+      id: -1,
+      languageCode: 'eng',
+      title: 'Internal storage mock',
+      description: 'Internal storage mock description',
+      storageId: -1,
+      backupFrequency: 'weekly',
+    },
+  ],
 };
 
 export const mockStorage: Storage = {
@@ -21,4 +29,9 @@ export const mockStorage: Storage = {
   id: -2,
   internalStorageId: -1,
   title: 'Internal storage mock',
+};
+
+export const mockInternalStorageSearchResult: SearchResult<InternalStorage> = {
+  items: [mockInternalStorage],
+  search: null,
 };

--- a/libs/damap/src/lib/services/backend.service.ts
+++ b/libs/damap/src/lib/services/backend.service.ts
@@ -18,7 +18,10 @@ import { DmpListItem } from '../domain/dmp-list-item';
 import { FeedbackService } from './feedback.service';
 import { Gdpr } from '../domain/gdpr';
 import { Injectable } from '@angular/core';
-import { InternalStorage } from '../domain/internal-storage';
+import {
+  InternalStorage,
+  InternalStorageTranslation,
+} from '../domain/internal-storage';
 import { Observable } from 'rxjs';
 import { Project } from '../domain/project';
 import { RepositoryDetails } from '../domain/repository-details';
@@ -210,7 +213,9 @@ export class BackendService {
   getInternalStorages(): Observable<InternalStorage[]> {
     const langCode = 'eng'; // TODO: Replace with template lang in the future
     return this.http
-      .get<InternalStorage[]>(`${this.backendUrl}storages/${langCode}`)
+      .get<
+        InternalStorage[]
+      >(`${this.backendUrl}storages?languageCode=${langCode}`)
       .pipe(retry(3), catchError(this.handleError('http.error.storages')));
   }
 
@@ -327,6 +332,90 @@ export class BackendService {
 
   getGdpr(): Observable<Gdpr[]> {
     return this.http.get<Gdpr[]>(`${this.backendUrl}gdpr/extended`);
+  }
+
+  createInternalStorage(storage: InternalStorage): Observable<InternalStorage> {
+    return this.http.post<InternalStorage>(
+      `${this.backendUrl}storages`,
+      storage,
+    );
+  }
+
+  getInternalStorage(id: number): Observable<InternalStorage> {
+    return this.http.get<InternalStorage>(`${this.backendUrl}storages/${id}`);
+  }
+
+  updateInternalStorage(storage: InternalStorage): Observable<InternalStorage> {
+    return this.http.put<InternalStorage>(
+      `${this.backendUrl}storages/${storage.id}`,
+      storage,
+    );
+  }
+
+  deleteInternalStorage(id: number): Observable<InternalStorage> {
+    return this.http.delete<InternalStorage>(
+      `${this.backendUrl}storages/${id}`,
+    );
+  }
+
+  searchInternalStorage(queryParams: {
+    [key: string]: string[];
+  }): Observable<SearchResult<InternalStorage>> {
+    let params = new HttpParams();
+    for (const key in queryParams) {
+      if (queryParams.hasOwnProperty(key)) {
+        queryParams[key]?.forEach(item => (params = params.append(key, item)));
+      }
+    }
+    return this.http.get<SearchResult<InternalStorage>>(
+      `${this.backendUrl}storages`,
+      {
+        params,
+      },
+    );
+  }
+
+  createInternalStorageTranslation(
+    translation: InternalStorageTranslation,
+  ): Observable<InternalStorageTranslation> {
+    return this.http.post<InternalStorageTranslation>(
+      `${this.backendUrl}storages/${translation.storageId}/translations`,
+      translation,
+    );
+  }
+
+  getInternalStorageTranslations(
+    id: number,
+  ): Observable<InternalStorageTranslation[]> {
+    return this.http.get<InternalStorageTranslation[]>(
+      `${this.backendUrl}storages/${id}/translations/`,
+    );
+  }
+
+  updateInternalStorageTranslation(
+    translation: InternalStorageTranslation,
+  ): Observable<InternalStorageTranslation> {
+    return this.http.put<InternalStorageTranslation>(
+      `${this.backendUrl}storages/${translation.storageId}/translations/${translation.id}`,
+      translation,
+    );
+  }
+
+  deleteInternalStorageTranslation(
+    storageId: number,
+    id: number,
+  ): Observable<InternalStorageTranslation> {
+    return this.http.delete<InternalStorageTranslation>(
+      `${this.backendUrl}storages/${storageId}/translations/${id}`,
+    );
+  }
+
+  getAllInternalStorageTranslationsForStorage(
+    id: number,
+  ): Observable<InternalStorageTranslation[]> {
+    return this.http.get<InternalStorageTranslation[]>(
+      `${this.backendUrl}storages/${id}/translations/`,
+    );
   }
 
   private handleError(message = 'http.error.standard') {

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -351,9 +351,21 @@ export class FormService {
 
   public addStorageToForm(storage: InternalStorage) {
     const storageFormGroup = this.createStorageFormGroup();
+
+    if (storage.translations.length === 0) {
+      return;
+    }
+
+    const translation = storage.translations.find(
+      t => t.languageCode === 'eng',
+    );
+    const title: string = translation
+      ? translation.title
+      : storage.translations[0].title;
+
     storageFormGroup.patchValue({
       internalStorageId: storage.id,
-      title: storage.title,
+      title: title,
     });
     (this.form.get('storage') as UntypedFormArray).push(storageFormGroup);
   }
@@ -435,6 +447,62 @@ export class FormService {
       retentionPeriod: [10],
       source: [DataSource.NEW, Validators.required],
       datasetId: [null],
+    });
+  }
+
+  public createInternalStorageFormGroup(): UntypedFormGroup {
+    return this.formBuilder.group({
+      id: [null, { disabled: true }],
+      url: [
+        '',
+        [
+          Validators.required,
+          Validators.maxLength(this.TEXT_SHORT_LENGTH),
+          notEmptyValidator(),
+        ],
+      ],
+      storageLocation: [
+        '',
+        [
+          Validators.required,
+          Validators.maxLength(this.TEXT_SHORT_LENGTH),
+          notEmptyValidator(),
+        ],
+      ],
+      backupLocation: [
+        '',
+        [
+          Validators.required,
+          Validators.maxLength(this.TEXT_SHORT_LENGTH),
+          notEmptyValidator(),
+        ],
+      ],
+      active: [true],
+    });
+  }
+
+  public createInternalStorageTranslationFormGroup(): UntypedFormGroup {
+    return this.formBuilder.group({
+      id: [null, { disabled: true }],
+      storageId: [null, { disabled: true }],
+      title: [
+        '',
+        [
+          Validators.required,
+          Validators.maxLength(this.TEXT_SHORT_LENGTH),
+          notEmptyValidator(),
+        ],
+      ],
+      languageCode: [
+        '',
+        [
+          Validators.required,
+          Validators.maxLength(this.TEXT_SHORT_LENGTH),
+          notEmptyValidator(),
+        ],
+      ],
+      description: ['', [Validators.maxLength(this.TEXT_MAX_LENGTH)]],
+      backupFrequency: ['', [Validators.maxLength(this.TEXT_SHORT_LENGTH)]],
     });
   }
 

--- a/libs/damap/src/lib/store/effects/internal-storage.effects.ts
+++ b/libs/damap/src/lib/store/effects/internal-storage.effects.ts
@@ -17,12 +17,14 @@ export class InternalStorageEffects {
       this.actions$.pipe(
         ofType(InternalStorageAction.loadInternalStorages),
         switchMap(_ =>
-          this.backendService.getInternalStorages().pipe(
-            map(internalStorages =>
-              InternalStorageAction.internalStoragesLoaded({
-                internalStorages,
-              }),
-            ),
+          this.backendService.searchInternalStorage({}).pipe(
+            map(internalStorages => {
+              // We now get at least any language translation, so we can display the title
+              const items = internalStorages.items;
+              return InternalStorageAction.internalStoragesLoaded({
+                internalStorages: items,
+              });
+            }),
             catchError(() =>
               of(InternalStorageAction.failedToLoadInternalStorages()),
             ),

--- a/libs/damap/src/lib/widgets/internal-storage-table/dialog/delete-storage-warning-dialog.component.ts
+++ b/libs/damap/src/lib/widgets/internal-storage-table/dialog/delete-storage-warning-dialog.component.ts
@@ -3,9 +3,10 @@ import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { DeleteWarningDialogComponent } from '../../delete-warning-dialog/delete-warning-dialog.component';
 
 @Component({
-  selector: 'damap-delete-warning-dialog',
+  selector: 'damap-delete-storage-warning-dialog',
   standalone: true,
   imports: [CommonModule, TranslateModule, MatDialogModule, MatButtonModule],
   template: `
@@ -23,8 +24,8 @@ import { TranslateModule } from '@ngx-translate/core';
     </mat-dialog-actions>
   `,
 })
-export class DeleteWarningDialogComponent {
-  getDeleteContent(): string {
-    return 'dialog.delete.content.dmp';
+export class DeleteStorageWarningDialogComponent extends DeleteWarningDialogComponent {
+  override getDeleteContent(): string {
+    return 'dialog.delete.content.storage';
   }
 }

--- a/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.css
+++ b/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.css
@@ -1,0 +1,11 @@
+.mat-column-url,
+.mat-column-storageLocation,
+.mat-column-backupLocation {
+  max-width: 20vw;
+  word-wrap: break-word;
+  white-space: normal;
+}
+
+.danger-icon-color {
+  color: var(--error-color);
+}

--- a/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.html
+++ b/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.html
@@ -1,0 +1,78 @@
+<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+  <!-- URL Column -->
+  <ng-container matColumnDef="url">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.url" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">{{ element.url }}</td>
+  </ng-container>
+
+  <!-- Storage Location Column -->
+  <ng-container matColumnDef="storageLocation">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.storageLocation" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">{{ element.storageLocation }}</td>
+  </ng-container>
+
+  <!-- Backup Location Column -->
+  <ng-container matColumnDef="backupLocation">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.backupLocation" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">{{ element.backupLocation }}</td>
+  </ng-container>
+
+  <!-- Active Column -->
+  <ng-container matColumnDef="active">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.active" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">
+      <mat-slide-toggle
+        [checked]="element.active"
+        (change)="toggleActivation(element.id)"></mat-slide-toggle>
+    </td>
+  </ng-container>
+
+  <!-- Edit Column -->
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>
+      {{ "admin.table.header.action" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">
+      <button mat-icon-button [matMenuTriggerFor]="menu">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item (click)="editTranslations(element.id)">
+          <mat-icon>language_us</mat-icon>
+          {{ "admin.table.action.translation" | translate }}
+        </button>
+        <button mat-menu-item (click)="editStorage(element.id)">
+          <mat-icon>edit</mat-icon>
+          {{ "admin.table.action.edit" | translate }}
+        </button>
+        <mat-divider></mat-divider>
+        <button mat-menu-item (click)="deleteStorage(element.id)">
+          <mat-icon class="danger-icon-color">delete</mat-icon>
+          {{ "admin.table.action.delete" | translate }}
+        </button>
+      </mat-menu>
+    </td>
+  </ng-container>
+
+  <!-- Header and Row Definitions -->
+  <tr mat-header-row *matHeaderRowDef="tableHeaders"></tr>
+  <tr mat-row *matRowDef="let row; columns: tableHeaders"></tr>
+
+  <!-- No Data Row -->
+  <tr class="mat-row" *matNoDataRow>
+    <td class="mat-cell" colspan="2">{{ "admin.table.empty" | translate }}</td>
+  </tr>
+</table>
+
+<mat-paginator
+  [pageSize]="10"
+  [pageSizeOptions]="[10, 15, 20]"
+  showFirstLastButtons></mat-paginator>

--- a/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.ts
+++ b/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.ts
@@ -1,0 +1,146 @@
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { InternalStorage } from '../../domain/internal-storage';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { BackendService } from '../../services/backend.service';
+import { FeedbackService } from '../../services/feedback.service';
+import { MatDialog } from '@angular/material/dialog';
+import { InternalStorageDialogComponent } from '../../components/admin/internal-storage-dialog/internal-storage-dialog.component';
+import { DeleteStorageWarningDialogComponent } from './dialog/delete-storage-warning-dialog.component';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'damap-internal-storage-table',
+  templateUrl: './internal-storage-table.component.html',
+  styleUrls: ['./internal-storage-table.component.css'],
+})
+export class InternalStorageTableComponent implements AfterViewInit, OnChanges {
+  @Output() selectInternalStorage = new EventEmitter<number>();
+
+  constructor(
+    private backendService: BackendService,
+    private feedbackService: FeedbackService,
+    private dialog: MatDialog,
+    private translateService: TranslateService,
+  ) {}
+
+  @Input() internalStorages: InternalStorage[] = [];
+  dataSource = new MatTableDataSource<InternalStorage>();
+
+  readonly tableHeaders: string[] = [
+    'url',
+    'storageLocation',
+    'backupLocation',
+    'active',
+    'actions',
+  ];
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.internalStorages) {
+      this.dataSource.data = this.internalStorages;
+    }
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+
+    this.dataSource.filterPredicate = (data: InternalStorage, filter: string) =>
+      data.url?.toLowerCase().includes(filter.trim().toLowerCase());
+  }
+
+  toggleActivation(id: number) {
+    const storage = this.internalStorages.find(s => s.id === id);
+    const storageCopy = { ...storage };
+    storageCopy.active = !storage.active;
+    this.backendService.updateInternalStorage(storageCopy).subscribe(() => {
+      this.internalStorages = this.internalStorages.map(s =>
+        s.id === id ? storageCopy : s,
+      );
+      this.dataSource.data = this.internalStorages;
+    });
+  }
+
+  deleteStorage(id: number) {
+    this.dialog
+      .open(DeleteStorageWarningDialogComponent, {
+        data: { deleteType: 'storage' },
+      })
+      .afterClosed()
+      .subscribe({
+        next: response => {
+          if (response) {
+            this.backendService.deleteInternalStorage(id).subscribe(
+              () => {
+                this.internalStorages = this.internalStorages.filter(
+                  s => s.id !== id,
+                );
+                this.dataSource.data = this.internalStorages;
+                this.feedbackService.success('http.success.storage.delete');
+                this.editTranslations(null);
+              },
+              error => {
+                if (error.status === 409) {
+                  this.feedbackService.error(
+                    this.translateService.instant(
+                      'http.error.storageErrors.stillInUse',
+                    ),
+                  );
+                  return;
+                } else {
+                  this.feedbackService.error(error.message);
+                }
+              },
+            );
+          }
+        },
+      });
+  }
+
+  editStorage(id: number) {
+    const storage = this.internalStorages.find(s => s.id === id);
+
+    const dialogRef = this.dialog.open(InternalStorageDialogComponent, {
+      width: '75%',
+      maxWidth: '800px',
+      data: { storage: { ...storage }, mode: 'edit' },
+    });
+
+    dialogRef.afterClosed().subscribe(storage => {
+      if (storage) {
+        this.backendService.updateInternalStorage(storage).subscribe(
+          () => {
+            this.internalStorages = this.internalStorages.map(s =>
+              s.id === storage.id ? storage : s,
+            );
+            this.dataSource.data = this.internalStorages;
+            this.selectInternalStorage.emit(storage.id);
+            this.feedbackService.success('http.success.storage.edit');
+          },
+          error => {
+            this.feedbackService.error(error.message);
+          },
+        );
+      }
+    });
+  }
+
+  editTranslations(storageId: number) {
+    this.selectInternalStorage.emit(storageId);
+  }
+}

--- a/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.module.ts
+++ b/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.module.ts
@@ -1,0 +1,59 @@
+import { CommonModule } from '@angular/common';
+import { InternalStorageTableComponent } from './internal-storage-table.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    TranslateModule,
+
+    // Materials
+    MatFormFieldModule,
+    MatInputModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDividerModule,
+    MatPaginatorModule,
+    MatSelectModule,
+    MatSortModule,
+    MatMenuModule,
+    MatTooltipModule,
+    MatSlideToggleModule,
+  ],
+  declarations: [InternalStorageTableComponent],
+  exports: [
+    CommonModule,
+    RouterModule,
+    InternalStorageTableComponent,
+
+    // Materials
+    MatFormFieldModule,
+    MatInputModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDividerModule,
+    MatPaginatorModule,
+    MatSelectModule,
+    MatSortModule,
+    MatMenuModule,
+    MatTooltipModule,
+  ],
+})
+export class InternalStorageTableModule {}

--- a/libs/damap/src/lib/widgets/internal-storage-translation-table/dialog/delete-storage-translation-warning-dialog.component.ts
+++ b/libs/damap/src/lib/widgets/internal-storage-translation-table/dialog/delete-storage-translation-warning-dialog.component.ts
@@ -3,9 +3,10 @@ import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { DeleteWarningDialogComponent } from '../../delete-warning-dialog/delete-warning-dialog.component';
 
 @Component({
-  selector: 'damap-delete-warning-dialog',
+  selector: 'damap-delete-storage-translation-warning-dialog',
   standalone: true,
   imports: [CommonModule, TranslateModule, MatDialogModule, MatButtonModule],
   template: `
@@ -23,8 +24,8 @@ import { TranslateModule } from '@ngx-translate/core';
     </mat-dialog-actions>
   `,
 })
-export class DeleteWarningDialogComponent {
-  getDeleteContent(): string {
-    return 'dialog.delete.content.dmp';
+export class DeleteStorageTranslationWarningDialogComponent extends DeleteWarningDialogComponent {
+  override getDeleteContent(): string {
+    return 'dialog.delete.content.storageTranslation';
   }
 }

--- a/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.css
+++ b/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.css
@@ -1,0 +1,17 @@
+.mat-column-title,
+.mat-column-description,
+.mat-column-backupFrequency {
+  max-width: 20vw;
+  word-wrap: break-word;
+  white-space: normal;
+  vertical-align: top;
+}
+
+.mat-column-languageCode,
+.mat-column-actions {
+  vertical-align: top;
+}
+
+.danger-icon-color {
+  color: var(--error-color);
+}

--- a/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.html
+++ b/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.html
@@ -1,0 +1,72 @@
+<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+  <!-- Language Code Column -->
+  <ng-container matColumnDef="languageCode">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.langugageCode" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">{{ element.languageCode }}</td>
+  </ng-container>
+
+  <!-- Title Column -->
+  <ng-container matColumnDef="title">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.title" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+  </ng-container>
+
+  <!-- Description Column -->
+  <ng-container matColumnDef="description">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.description" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">{{ element.description }}</td>
+  </ng-container>
+
+  <!-- Backup Frequency Column -->
+  <ng-container matColumnDef="backupFrequency">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "admin.table.header.backupFrequency" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">{{ element.backupFrequency }}</td>
+  </ng-container>
+
+  <!-- Edit Column -->
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>
+      {{ "admin.table.header.action" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">
+      <button mat-icon-button [matMenuTriggerFor]="menu">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item (click)="editStorageTranslation(element.id)">
+          <mat-icon>edit</mat-icon>
+          {{ "admin.table.action.edit" | translate }}
+        </button>
+        <mat-divider></mat-divider>
+        <button mat-menu-item (click)="deleteStorageTranslation(element.id)">
+          <mat-icon class="danger-icon-color">delete</mat-icon>
+          {{ "admin.table.action.delete" | translate }}
+        </button>
+      </mat-menu>
+    </td>
+  </ng-container>
+
+  <!-- Header and Row Definitions -->
+  <tr mat-header-row *matHeaderRowDef="tableHeaders"></tr>
+  <tr mat-row *matRowDef="let row; columns: tableHeaders"></tr>
+
+  <!-- No Data Row -->
+  <tr class="mat-row" *matNoDataRow>
+    <td class="mat-cell" colspan="2">
+      {{ "admin.table.no-selected" | translate }}
+    </td>
+  </tr>
+</table>
+
+<mat-paginator
+  [pageSize]="10"
+  [pageSizeOptions]="[10, 15, 20]"
+  showFirstLastButtons></mat-paginator>

--- a/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.ts
+++ b/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.ts
@@ -1,0 +1,157 @@
+import {
+  AfterViewInit,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  InternalStorage,
+  InternalStorageTranslation,
+} from '../../domain/internal-storage';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { BackendService } from '../../services/backend.service';
+import { FeedbackService } from '../../services/feedback.service';
+import { MatDialog } from '@angular/material/dialog';
+import { InternalStorageDialogComponent } from '../../components/admin/internal-storage-dialog/internal-storage-dialog.component';
+import { InternalStorageTranslationDialogComponent } from '../../components/admin/internal-storage-translation-dialog/internal-storage-translation-dialog.component';
+import { DeleteWarningDialogComponent } from '../delete-warning-dialog/delete-warning-dialog.component';
+import { DeleteStorageTranslationWarningDialogComponent } from './dialog/delete-storage-translation-warning-dialog.component';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'damap-internal-storage-translation-table',
+  templateUrl: './internal-storage-translation-table.component.html',
+  styleUrls: ['./internal-storage-translation-table.component.css'],
+})
+export class InternalStorageTranslationTableComponent
+  implements AfterViewInit, OnChanges
+{
+  constructor(
+    private backendService: BackendService,
+    private feedbackService: FeedbackService,
+    private dialog: MatDialog,
+    private translateService: TranslateService,
+  ) {}
+
+  @Input() internalStorageTranslations: InternalStorageTranslation[] = [];
+  @Input() selectedInternalStorageId: number;
+
+  dataSource = new MatTableDataSource<InternalStorageTranslation>();
+
+  readonly tableHeaders: string[] = [
+    'languageCode',
+    'title',
+    'description',
+    'backupFrequency',
+    'actions',
+  ];
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.internalStorageTranslations) {
+      this.dataSource.data = this.internalStorageTranslations;
+    }
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+
+    this.dataSource.filterPredicate = (
+      data: InternalStorageTranslation,
+      filter: string,
+    ) => data.title?.toLowerCase().includes(filter.trim().toLowerCase());
+  }
+
+  deleteStorageTranslation(id: number) {
+    this.dialog
+      .open(DeleteStorageTranslationWarningDialogComponent)
+      .afterClosed()
+      .subscribe({
+        next: response => {
+          if (response) {
+            const translation = this.internalStorageTranslations.find(
+              t => t.id === id,
+            );
+            this.backendService
+              .deleteInternalStorageTranslation(translation.storageId, id)
+              .subscribe(
+                () => {
+                  this.internalStorageTranslations =
+                    this.internalStorageTranslations.filter(t => t.id !== id);
+                  this.dataSource.data = this.internalStorageTranslations;
+                  this.feedbackService.success(
+                    'http.success.storage.translations.delete',
+                  );
+                },
+                error => {
+                  // Check if HTTP code 400, if yes, last translation cannot be deleted
+                  if (error.status === 400) {
+                    this.feedbackService.error(
+                      this.translateService.instant(
+                        'http.error.storageErrors.lastTranslation',
+                      ),
+                    );
+                    return;
+                  } else {
+                    this.feedbackService.error(error.message);
+                  }
+                },
+              );
+          }
+        },
+      });
+  }
+
+  editStorageTranslation(id: number) {
+    const translation = this.internalStorageTranslations.find(t => t.id === id);
+
+    const dialogRef = this.dialog.open(
+      InternalStorageTranslationDialogComponent,
+      {
+        width: '75%',
+        maxWidth: '800px',
+        data: {
+          translation: { ...translation },
+          mode: 'edit',
+          storageId: this.selectedInternalStorageId,
+        },
+      },
+    );
+
+    dialogRef.afterClosed().subscribe(translation => {
+      if (translation) {
+        this.backendService
+          .updateInternalStorageTranslation(translation)
+          .subscribe(
+            () => {
+              this.internalStorageTranslations =
+                this.internalStorageTranslations.map(t =>
+                  t.id === translation.id ? translation : t,
+                );
+              this.dataSource.data = this.internalStorageTranslations;
+              this.feedbackService.success(
+                'http.success.storage.translations.edit',
+              );
+            },
+            error => {
+              // Make sure to show the correct error message (depending on the response of the backend as we do not have a unified error message format right now)
+              if (error.error?.message) {
+                this.feedbackService.error(error.error.message);
+              } else {
+                this.feedbackService.error(error.message);
+              }
+            },
+          );
+      }
+    });
+  }
+}

--- a/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.module.ts
+++ b/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.module.ts
@@ -1,0 +1,57 @@
+import { CommonModule } from '@angular/common';
+import { InternalStorageTranslationTableComponent } from './internal-storage-translation-table.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    TranslateModule,
+
+    // Materials
+    MatFormFieldModule,
+    MatInputModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDividerModule,
+    MatPaginatorModule,
+    MatSelectModule,
+    MatSortModule,
+    MatMenuModule,
+    MatTooltipModule,
+  ],
+  declarations: [InternalStorageTranslationTableComponent],
+  exports: [
+    CommonModule,
+    RouterModule,
+    InternalStorageTranslationTableComponent,
+
+    // Materials
+    MatFormFieldModule,
+    MatInputModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDividerModule,
+    MatPaginatorModule,
+    MatSelectModule,
+    MatSortModule,
+    MatMenuModule,
+    MatTooltipModule,
+  ],
+})
+export class InternalStoragaTranslationTableModule {}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Feature

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->
Implementation of admin only UI to manage internal storages

#### Dependencies

Requires backend branch:
https://github.com/tuwien-csd/damap-backend/tree/gk/95-allow-internal-storages-to-be-disabled-for-the-frontend

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-236
