### PR TITLE
Fix: Set the id in the url after the DMP has been created

### DIFF
--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { filter, Observable, Subject, Subscription, take } from 'rxjs';
 import { Store, select } from '@ngrx/store';
 import {
   createDmp,
@@ -16,7 +16,11 @@ import { ExportWarningDialogComponent } from '../../../widgets/export-warning-di
 import { FormGroup } from '@angular/forms';
 import { FormService } from '../../../services/form.service';
 import { selectDmpSaving } from '../../../store/selectors/dmp.selectors';
-import { selectFormChanged } from '../../../store/selectors/form.selectors';
+import {
+  selectForm,
+  selectFormChanged,
+} from '../../../store/selectors/form.selectors';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'app-actions',
@@ -42,6 +46,7 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
     private formService: FormService,
     private dialog: MatDialog,
     private store: Store<AppState>,
+    private location: Location,
   ) {
     this.dmpForm = this.formService.dmpForm;
   }
@@ -72,6 +77,16 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
         this.store.dispatch(updateDmp({ dmp }));
       } else {
         this.store.dispatch(createDmp({ dmp }));
+        this.store
+          .select(selectForm)
+          .pipe(
+            filter(formState => !!formState?.id),
+            take(1),
+          )
+          .subscribe(formState => {
+            const newDmpId = formState?.id;
+            this.location.go(`/dmp/${newDmpId}`);
+          });
       }
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Set the id of the DMP recently created in the URL 
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
tuwien-csd/damap-frontend/issues/301

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->
#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->
Check the id of the new DMP in the url without refresh all the page.
#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-301
