### PR TITLE
Live Preview: Show preview of export document in popup

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -468,7 +468,11 @@
     "save": "Save changes",
     "discard": "Discard changes",
     "version": "Save new version",
-    "export": "Export document"
+    "export": "Export document",
+    "preview": {
+      "tooltipDisabled": "Please save the DMP before being able to preview it.",
+      "content": "Show preview"
+    }
   },
   "form": {
     "error": {
@@ -938,5 +942,12 @@
   "fair": "FAIR",
   "contenttypes": "Content types",
   "metadatastandards": "Metadata standards",
-  "or": "or"
+  "or": "or",
+  "preview": {
+    "title": "Live Preview",
+    "info": "Only data that has been saved will be displayed in the preview, if you are missing recent changes please save your DMP first.",
+    "templateSelection": "Choose preview format",
+    "loading": "Loading",
+    "requestTemplateSelection": "Please select a template in the dropdown"
+  }
 }

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.html
@@ -24,6 +24,17 @@
       [disabled]="dmpForm.invalid || this.savingDmp">
       {{ "button.version" | translate }}
     </button>
+    <div
+      matTooltip="{{ 'button.preview.tooltipDisabled' | translate }}"
+      [matTooltipDisabled]="previewEnabled()">
+      <button
+        class="action-button button-color-primary"
+        mat-raised-button
+        [disabled]="!previewEnabled()"
+        (click)="showPreview()">
+        {{ "button.preview.content" | translate }}
+      </button>
+    </div>
     <button
       class="action-button button-color-primary"
       mat-raised-button

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.spec.ts
@@ -19,12 +19,16 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TranslateTestingModule } from '../../../testing/translate-testing/translate-testing.module';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BackendService } from '../../../services/backend.service';
+import { LivePreviewModule } from '../live-preview/live-preview.module';
+import { LivePreviewComponent } from '../live-preview/live-preview.component';
 
 describe('DmpActionsComponent', () => {
   let component: DmpActionsComponent;
   let fixture: ComponentFixture<DmpActionsComponent>;
   let loader: HarnessLoader;
   let store: MockStore;
+  let backendSpy: jasmine.SpyObj<BackendService>;
   const initialState = {
     damap: {
       form: { dmp: null, changed: false },
@@ -33,6 +37,10 @@ describe('DmpActionsComponent', () => {
   };
 
   beforeEach(waitForAsync(() => {
+    backendSpy = jasmine.createSpyObj(
+      Object.getOwnPropertyNames(BackendService.prototype),
+    );
+
     TestBed.configureTestingModule({
       imports: [
         ExportWarningModule,
@@ -42,10 +50,14 @@ describe('DmpActionsComponent', () => {
         NoopAnimationsModule,
         TranslateTestingModule,
         FormTestingModule,
+        LivePreviewModule,
       ],
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [DmpActionsComponent, SaveVersionDialogComponent],
-      providers: [provideMockStore({ initialState })],
+      providers: [
+        provideMockStore({ initialState }),
+        { provide: BackendService, useValue: backendSpy },
+      ],
     }).compileComponents();
     store = TestBed.inject(MockStore);
   }));
@@ -93,11 +105,11 @@ describe('DmpActionsComponent', () => {
 
     await inputs[0].setValue('test');
     const buttons = await loader.getAllHarnesses(MatButtonHarness);
-    expect(buttons.length).toBe(6);
-    expect(await buttons[5].getText()).toBe('dmp.dialog.button.save');
-    expect(await buttons[5].isDisabled()).toBe(false);
+    expect(buttons.length).toBe(7);
+    expect(await buttons[6].getText()).toBe('dmp.dialog.button.save');
+    expect(await buttons[6].isDisabled()).toBe(false);
 
-    await buttons[5].click();
+    await buttons[6].click();
     dialogs = await loader.getAllHarnesses(MatDialogHarness);
     expect(store.dispatch).toHaveBeenCalledTimes(1);
     expect(dialogs.length).toBe(0);

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
@@ -21,6 +21,8 @@ import {
   selectFormChanged,
 } from '../../../store/selectors/form.selectors';
 import { Location } from '@angular/common';
+import { LivePreviewComponent } from '../live-preview/live-preview.component';
+import { BackendService } from '../../../services/backend.service';
 
 @Component({
   selector: 'app-actions',
@@ -47,6 +49,7 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private store: Store<AppState>,
     private location: Location,
+    private backendService: BackendService,
   ) {
     this.dmpForm = this.formService.dmpForm;
   }
@@ -136,6 +139,34 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
         }
       }
     });
+  }
+
+  previewEnabled(): boolean {
+    return this.dmpForm.value.id !== null;
+  }
+
+  showPreview(): void {
+    if (this.dmpForm.controls.project?.getRawValue()?.funderSupported) {
+      this.backendService
+        .getTemplateType(this.dmpForm.value.id)
+        .subscribe(response => {
+          const dialogRef = this.dialog.open(LivePreviewComponent, {
+            maxHeight: '90vh',
+            maxWidth: '70vw',
+            width: '70vw',
+            height: '90vh',
+          });
+
+          dialogRef.componentInstance.selectedTemplate = response;
+        });
+    } else {
+      const dialogRef = this.dialog.open(LivePreviewComponent, {
+        maxHeight: '90vh',
+        maxWidth: '70vw',
+        width: '70vw',
+        height: '90vh',
+      });
+    }
   }
 }
 

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.module.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.module.ts
@@ -14,6 +14,8 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { SaveStatusModule } from '../../../widgets/save-status/save-status.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { LivePreviewModule } from '../live-preview/live-preview.module';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [DmpActionsComponent, SaveVersionDialogComponent],
@@ -26,12 +28,14 @@ import { TranslateModule } from '@ngx-translate/core';
     MatFormFieldModule,
     MatInputModule,
     MatProgressBarModule,
+    MatTooltipModule,
   ],
   imports: [
     CommonModule,
     TranslateModule,
     RouterModule,
     SaveStatusModule,
+    LivePreviewModule,
 
     // Materials
     MatDialogModule,
@@ -40,6 +44,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatFormFieldModule,
     MatInputModule,
     MatProgressBarModule,
+    MatTooltipModule,
   ],
 })
 export class DmpActionsModule {}

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -1,6 +1,6 @@
 import { ActivatedRoute, Router } from '@angular/router';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, Subscription, take } from 'rxjs';
 import { Store } from '@ngrx/store';
 import {
   UntypedFormArray,
@@ -30,6 +30,7 @@ import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { Config } from '../../domain/config';
 import { InfoLabelService } from '../../services/infoLabel.service';
 import { InfoBoxDetails } from '../../domain/infoBox-details';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-dmp',

--- a/libs/damap/src/lib/components/dmp/dmp.module.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.module.ts
@@ -25,6 +25,7 @@ import { SpecifyDataModule } from './specify-data/specify-data.module';
 import { SummaryModule } from './summary/summary.module';
 import { VersionModule } from '../version/version.module';
 import { InfoCardComponent } from '../../widgets/info-card/info-card.component';
+import { LivePreviewModule } from './live-preview/live-preview.module';
 
 // required for AOT compilation
 export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
@@ -68,6 +69,9 @@ export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
     ReuseModule,
     CostsModule,
     SummaryModule,
+
+    // Live preview
+    LivePreviewModule,
     InfoCardComponent,
     // Materials
     MatStepperModule,

--- a/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.css
+++ b/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.css
@@ -1,0 +1,51 @@
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.top-right-button {
+  position: absolute;
+  right: 16px;
+  top: 16px;
+}
+
+.select-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.expanded-select {
+  flex: 1;
+}
+
+.loading-icon {
+  animation: spin 1s linear infinite; /* Defines a continuous spin */
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.no-preview {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.full-height {
+  height: 100%;
+}
+
+.max-height-90 {
+  max-height: 90%;
+}

--- a/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.html
+++ b/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.html
@@ -1,0 +1,45 @@
+<div class="dialog-header">
+  <h1 mat-dialog-title>{{ "preview.title" | translate }}</h1>
+  <button mat-button mat-dialog-close class="top-right-button">
+    <mat-icon style="margin: 0">close</mat-icon>
+  </button>
+</div>
+
+<mat-dialog-content class="full-height max-height-90">
+  <div class="container full-height">
+    <p>
+      {{ "preview.info" | translate }}
+    </p>
+    <ng-container>
+      <div class="select-row">
+        <mat-form-field class="expanded-select" appearance="fill">
+          <mat-label>{{ "preview.templateSelection" | translate }}</mat-label>
+          <mat-select
+            [(value)]="selectedTemplate"
+            (selectionChange)="onTemplateChange($event)">
+            <mat-option
+              *ngFor="let id of dmpTemplate | keyvalue"
+              [value]="id.key">
+              {{ id.value | translate }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+    </ng-container>
+    <br />
+    <div *ngIf="pdfUrl" style="height: 80vh">
+      <iframe
+        [src]="pdfUrl"
+        width="100%"
+        height="100%"
+        title="preview"></iframe>
+    </div>
+    <div *ngIf="!pdfUrl && selectedTemplate.length !== 0" class="no-preview">
+      <mat-icon class="loading-icon">autorenew</mat-icon>
+      <p>{{ "preview.info" | translate }}</p>
+    </div>
+    <div *ngIf="!pdfUrl && selectedTemplate.length === 0" class="no-preview">
+      <p>{{ "preview.requestTemplateSelection" | translate }}</p>
+    </div>
+  </div>
+</mat-dialog-content>

--- a/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LivePreviewComponent } from './live-preview.component';
+import { of } from 'rxjs';
+import { MatDialogRef } from '@angular/material/dialog';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+describe('LivePreviewComponent', () => {
+  let component: LivePreviewComponent;
+  let fixture: ComponentFixture<LivePreviewComponent>;
+
+  beforeEach(async () => {
+    const matDialogRefMock = {
+      close: jasmine.createSpy('close'),
+      afterClosed: () => of(true),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, TranslateModule.forRoot()],
+      declarations: [LivePreviewComponent],
+      providers: [{ provide: MatDialogRef, useValue: matDialogRefMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LivePreviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.ts
+++ b/libs/damap/src/lib/components/dmp/live-preview/live-preview.component.ts
@@ -1,0 +1,54 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { ExportWarningDialogComponent } from '../../../widgets/export-warning-dialog/export-warning-dialog.component';
+import { MatDialogRef } from '@angular/material/dialog';
+import { BackendService } from '../../../services/backend.service';
+import { MatSelectChange } from '@angular/material/select';
+import { FormGroup } from '@angular/forms';
+import { FormService } from '../../../services/form.service';
+import { ETemplateType } from '../../../domain/enum/export-template-type.enum';
+import { DomSanitizer } from '@angular/platform-browser';
+
+@Component({
+  selector: 'damap-live-preview',
+  templateUrl: './live-preview.component.html',
+  styleUrl: './live-preview.component.css',
+})
+export class LivePreviewComponent implements OnInit {
+  @Input() selectedTemplate = '';
+
+  dmpForm: FormGroup;
+  dmpTemplate: any = ETemplateType;
+  pdfUrl: any = null;
+
+  constructor(
+    public dialogRef: MatDialogRef<ExportWarningDialogComponent>,
+    private backendService: BackendService,
+    private formService: FormService,
+    private sanitizer: DomSanitizer,
+  ) {
+    this.dmpForm = this.formService.dmpForm;
+  }
+
+  ngOnInit(): void {
+    this.refreshPreview();
+  }
+
+  refreshPreview(): void {
+    if (this.selectedTemplate) {
+      this.onTemplateChange({
+        value: this.selectedTemplate,
+      } as MatSelectChange);
+    }
+  }
+
+  onTemplateChange(template: MatSelectChange): void {
+    this.pdfUrl = null;
+
+    this.backendService
+      .getPreviewPDF(this.dmpForm.value.id, template.value)
+      .subscribe((response: any) => {
+        const url = window.URL.createObjectURL(response);
+        this.pdfUrl = this.sanitizer.bypassSecurityTrustResourceUrl(url);
+      });
+  }
+}

--- a/libs/damap/src/lib/components/dmp/live-preview/live-preview.module.ts
+++ b/libs/damap/src/lib/components/dmp/live-preview/live-preview.module.ts
@@ -1,0 +1,53 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatInputModule } from '@angular/material/input';
+import { SharedModule } from '../../../shared/shared.module';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
+import { LivePreviewComponent } from './live-preview.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TranslateModule,
+    ReactiveFormsModule,
+    SharedModule,
+
+    // Materials
+    MatIconModule,
+    MatSlideToggleModule,
+    MatFormFieldModule,
+    MatButtonModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatInputModule,
+    MatSelectModule,
+    MatDialogModule,
+  ],
+  declarations: [LivePreviewComponent],
+  exports: [
+    CommonModule,
+    TranslateModule,
+    ReactiveFormsModule,
+    SharedModule,
+    LivePreviewComponent,
+
+    // Materials
+    MatIconModule,
+    MatSlideToggleModule,
+    MatFormFieldModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatInputModule,
+    MatDialogModule,
+  ],
+})
+export class LivePreviewModule {}

--- a/libs/damap/src/lib/services/backend.service.ts
+++ b/libs/damap/src/lib/services/backend.service.ts
@@ -292,6 +292,17 @@ export class BackendService {
       });
   }
 
+  getPreviewPDF(dmpId: number, template: string): Observable<Blob> {
+    return this.http
+      .get(
+        `${this.backendUrl}document/${dmpId}/export?template=${template}&download=false&filetype=pdf`,
+        {
+          responseType: 'blob',
+        },
+      )
+      .pipe(catchError(this.handleError('http.error.document')));
+  }
+
   getDmpDocument(id: number): void {
     this.http
       .get(`${this.backendUrl}document/${id}`, {
@@ -332,6 +343,12 @@ export class BackendService {
 
   getGdpr(): Observable<Gdpr[]> {
     return this.http.get<Gdpr[]>(`${this.backendUrl}gdpr/extended`);
+  }
+
+  getTemplateType(dmpId: number): Observable<string> {
+    return this.http
+      .get<string>(`${this.backendUrl}document/${dmpId}/template_type`)
+      .pipe(retry(3), catchError(this.handleError('http.error.template')));
   }
 
   createInternalStorage(storage: InternalStorage): Observable<InternalStorage> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Display a rendered version of the current DMP in DOCX, displayed as PDF using an embed.

#### What does this PR do?

Add new button in the action bar to display the preview popup.

#### Dependencies

https://github.com/tuwien-csd/damap-backend/pull/260

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

