### PR TITLE
Feature: Add ability to edit email and orcid for contributors in a DMP and overwrite the default values

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -42,7 +42,10 @@
         "contact": {
           "person": "Contact person",
           "add": "Set as contact",
-          "remove": "Remove as contact"
+          "remove": "Remove as contact",
+          "edit": "Edit contact person",
+          "update": "Update",
+          "cancel": "Cancel"
         },
         "manual.input": {
           "show": "Add contributor manually",

--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -17,7 +17,8 @@
       [dmpForm]="dmpForm"
       (contactPerson)="changeContactPerson($event)"
       (contributorToAdd)="addContributor($event)"
-      (contributorToRemove)="removeContributor($event)">
+      (contributorToRemove)="removeContributor($event)"
+      (contributorToUpdate)="updateContributorDetails($event)">
     </app-dmp-people>
   </mat-step>
 

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -188,6 +188,10 @@ export class DmpComponent implements OnInit, OnDestroy {
     this.formService.removeContributorFromForm(index);
   }
 
+  updateContributorDetails(event: { idx: number; contributor: Contributor }) {
+    this.formService.upadteContributorOfForm(event.idx, event.contributor);
+  }
+
   addDataset(dataset: Dataset) {
     dataset.referenceHash = this.generateReferenceHash();
     this.formService.addDatasetToForm(dataset);

--- a/libs/damap/src/lib/components/dmp/people/people.component.css
+++ b/libs/damap/src/lib/components/dmp/people/people.component.css
@@ -45,3 +45,21 @@ mat-form-field {
   flex: 1;
   min-width: 100px;
 }
+
+.form-fields {
+  display: flex;
+  justify-content: space-between;
+  gap: 1em;
+  margin: 1em 0.5em -0.5em 0.5em;
+}
+
+.form-field {
+  flex: 1;
+}
+
+.form-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.25em;
+  margin-right: 0.5em;
+}

--- a/libs/damap/src/lib/components/dmp/people/people.component.html
+++ b/libs/damap/src/lib/components/dmp/people/people.component.html
@@ -2,67 +2,105 @@
 <div [formGroup]="dmpForm">
   <ng-container formArrayName="contributors">
     <div *ngIf="contributors.length > 0">
-      <mat-card
-        appearance="raised"
-        *ngFor="let contributor of contributors.controls; index as i"
-        class="card-selected">
-        <mat-card-content>
-          <div class="mat-card-container">
-            <div class="mat-card-left">
-              <div>
-                <mat-icon class="mat-icon-style">person</mat-icon>
-                {{ contributor.value.firstName }}
-                {{ contributor.value.lastName }}
-                <mat-icon
-                  *ngIf="contributor.value.contact"
-                  class="mat-icon-contact button-color-primary">
-                  contact_mail
-                </mat-icon>
-                <span class="sr-only">{{
-                  "dmp.steps.people.contact.person" | translate
-                }}</span>
+      <div *ngFor="let contributor of contributors.controls; index as i">
+        <mat-card appearance="raised" class="card-selected">
+          <mat-card-content>
+            <div class="mat-card-container">
+              <div class="mat-card-left">
+                <div>
+                  <mat-icon class="mat-icon-style">person</mat-icon>
+                  {{ contributor.value.firstName }}
+                  {{ contributor.value.lastName }}
+                  <mat-icon
+                    *ngIf="contributor.value.contact"
+                    class="mat-icon-contact button-color-primary">
+                    contact_mail
+                  </mat-icon>
+                  <span class="sr-only">{{
+                    "dmp.steps.people.contact.person" | translate
+                  }}</span>
+                </div>
+                <mat-icon class="mat-icon-style outline">mail</mat-icon>
+                {{ contributor.value.mbox }}
+                <app-orcid
+                  *ngIf="
+                    contributor.value.personId?.identifier &&
+                    contributor.value.personId?.type === identifierType.ORCID
+                  "
+                  [orcidId]="
+                    contributor.value.personId?.identifier
+                  "></app-orcid>
               </div>
-              <mat-icon class="mat-icon-style outline">mail</mat-icon>
-              {{ contributor.value.mbox }}
-              <app-orcid
-                *ngIf="
-                  contributor.value.personId?.identifier &&
-                  contributor.value.personId?.type === identifierType.ORCID
-                "
-                [orcidId]="contributor.value.personId?.identifier"></app-orcid>
+              <div [formGroupName]="i">
+                <mat-form-field appearance="fill">
+                  <mat-label>{{
+                    "dmp.steps.people.contributor.role" | translate
+                  }}</mat-label>
+                  <mat-select formControlName="role">
+                    <mat-option
+                      *ngFor="let role of roles | keyvalue"
+                      [value]="role.key">
+                      {{ translateEnumPrefix + role.value | translate }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div class="mat-card-right">
+                <button
+                  mat-icon-button
+                  (click)="changeContactPerson(contributor.value)"
+                  *ngIf="!contributor.value.contact"
+                  title="{{ 'dmp.steps.people.contact.add' | translate }}">
+                  <mat-icon>contact_mail</mat-icon>
+                </button>
+                <button
+                  mat-icon-button
+                  (click)="triggerUpdateContributorDetails(i)"
+                  title="{{ 'dmp.steps.people.contact.edit' | translate }}">
+                  <mat-icon>edit</mat-icon>
+                </button>
+                <button
+                  mat-icon-button
+                  (click)="removeContributor(i)"
+                  title="{{
+                    'dmp.steps.people.contributor.remove' | translate
+                  }}">
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </div>
             </div>
-            <div [formGroupName]="i">
-              <mat-form-field appearance="fill">
-                <mat-label>{{
-                  "dmp.steps.people.contributor.role" | translate
-                }}</mat-label>
-                <mat-select formControlName="role">
-                  <mat-option
-                    *ngFor="let role of roles | keyvalue"
-                    [value]="role.key">
-                    {{ translateEnumPrefix + role.value | translate }}
-                  </mat-option>
-                </mat-select>
-              </mat-form-field>
-            </div>
-            <div class="mat-card-right">
-              <button
-                mat-icon-button
-                (click)="changeContactPerson(contributor.value)"
-                *ngIf="!contributor.value.contact"
-                title="{{ 'dmp.steps.people.contact.add' | translate }}">
-                <mat-icon>contact_mail</mat-icon>
-              </button>
-              <button
-                mat-icon-button
-                (click)="removeContributor(i)"
-                title="{{ 'dmp.steps.people.contributor.remove' | translate }}">
-                <mat-icon>delete</mat-icon>
-              </button>
-            </div>
+          </mat-card-content>
+        </mat-card>
+        <div *ngIf="currentUpdateContributorIdx === i" [formGroup]="form">
+          <div class="form-fields">
+            <app-input-wrapper
+              [label]="
+                'dmp.steps.people.manual.input.question.mbox' | translate
+              "
+              [control]="mbox()"></app-input-wrapper>
+            <app-input-wrapper
+              [label]="
+                'dmp.steps.people.manual.input.question.orcid' | translate
+              "
+              [control]="identifier()"></app-input-wrapper>
           </div>
-        </mat-card-content>
-      </mat-card>
+          <div class="form-buttons">
+            <button
+              class="button-position button-color-primary"
+              mat-raised-button
+              [disabled]="form.invalid"
+              (click)="updateContributorDetails(i)">
+              {{ "dmp.steps.people.contact.update" | translate }}
+            </button>
+            <button
+              class="button-position button-color-primary"
+              mat-raised-button
+              (click)="cancelUpdateContributorDetails()">
+              {{ "dmp.steps.people.contact.cancel" | translate }}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </ng-container>
 </div>

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -324,6 +324,14 @@ export class FormService {
     (this.form.get('contributors') as UntypedFormArray).removeAt(index);
   }
 
+  public upadteContributorOfForm(index: number, contributor: Contributor) {
+    const contributor_ = (this.form.get('contributors') as UntypedFormArray).at(
+      index,
+    );
+
+    contributor_.patchValue(contributor);
+  }
+
   public addDatasetToForm(dataset: Dataset) {
     dataset.startDate = this.getStartDate();
 


### PR DESCRIPTION
## Description

The user can now click on the pencil icon present on each card showing a contributor to edit the email and orcid.

#### What does this PR do?

Introduce a new panel right below the current user to edit its details.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-293
