### PR TITLE
global: Use default behaviour for changedetector

### DIFF
--- a/apps/damap-frontend/src/app/components/layout/layout.component.ts
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.ts
@@ -1,6 +1,5 @@
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   OnInit,
   ViewChild,
@@ -19,7 +18,6 @@ import { BehaviorSubject, filter, Subscription } from 'rxjs';
 import * as layoutTemplate from '../../../assets/i18n/layout/en.json';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-layout',
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.css'],

--- a/apps/damap-frontend/src/app/components/layout/layout.component.ts
+++ b/apps/damap-frontend/src/app/components/layout/layout.component.ts
@@ -7,14 +7,14 @@ import {
 } from '@angular/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 
-import { AuthService } from '@damap/core';
+import { AuthService, DashboardComponent } from '@damap/core';
 import { ConfigService } from '../../services/config.service';
 import { MatSidenav } from '@angular/material/sidenav';
 import { TranslateService } from '@ngx-translate/core';
 import pkg from '../../../../../../package.json'; // eslint-disable-line
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { DmpComponent } from '../../../../../../libs/damap/src/lib/components/dmp/dmp.component'; // eslint-disable-line
-import { BehaviorSubject, filter, Subscription } from 'rxjs';
+import { filter, Subscription } from 'rxjs';
 import * as layoutTemplate from '../../../assets/i18n/layout/en.json';
 
 @Component({
@@ -24,7 +24,7 @@ import * as layoutTemplate from '../../../assets/i18n/layout/en.json';
 })
 export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('sidenav', { static: true }) sidenav!: MatSidenav;
-  @ViewChild('outlet') outlet: RouterOutlet;
+  @ViewChild('outlet') outlet: RouterOutlet | null;
 
   private routerEventsSubscription: Subscription;
   public title = 'Data Management Plan';
@@ -35,8 +35,7 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
   public isCollapsed: boolean = false;
   public templateDataLayout = layoutTemplate;
   public icon = 'info';
-  public infoString: BehaviorSubject<any> | null;
-  private dataInfoService: Subscription | null = null;
+  private dataInfoService: Subscription | null;
   public greeting: string;
   public instructions: string;
   public summaryLine: string;
@@ -62,8 +61,9 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
     this.observer.observe([Breakpoints.Handset]).subscribe(result => {
       this.isSmallScreen = result.matches;
       this.checkScreenSize();
-      this.handleRouteChange();
     });
+
+    this.handleRouteChange();
   }
 
   ngAfterViewInit(): void {
@@ -72,14 +72,12 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe(() => {
         this.handleRouteChange();
       });
-    this.handleRouteChange();
     this.checkScreenSize();
   }
 
   ngOnDestroy(): void {
-    if (this.routerEventsSubscription) {
-      this.routerEventsSubscription.unsubscribe();
-    }
+    this.dataInfoService?.unsubscribe();
+    this.routerEventsSubscription?.unsubscribe();
   }
 
   private checkScreenSize(): void {
@@ -99,29 +97,45 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
     this.isCollapsed = !this.isCollapsed;
   }
 
+  /**
+   * Handle UI updates when route changes. Update card content and listen to
+   * step changes of the DMP component.
+   * @return {void}
+   */
   private handleRouteChange(): void {
-    if (this.outlet && this.outlet.isActivated) {
-      const componentInstance = this.outlet.component;
-      if (componentInstance instanceof DmpComponent) {
-        const dmpComponent = componentInstance as DmpComponent;
-        this.infoString = dmpComponent.instructionStep$;
-        this.dataInfoService = dmpComponent.instructionStep$.subscribe(
-          value => {
-            this.greeting = this.replaceFirstname(this.name, value.greeting);
-            this.summaryLine = value.summaryLine;
-          },
-        );
-      } else {
-        this.greeting =
-          this.templateDataLayout.layout.menu.greeting +
-          ' ' +
-          this.name +
-          ' ' +
-          this.templateDataLayout.layout.menu.titleDashboard;
-        this.summaryLine = 'layout.menu.section';
-      }
+    // unsubscribe, if subscribed before. will subscribe again when redirecting to DMP component
+    this.dataInfoService?.unsubscribe();
+
+    const componentInstance =
+      this.outlet == null || !this.outlet.isActivated // outlet not yet initialized or not activated
+        ? null
+        : this.outlet.component;
+
+    if (componentInstance instanceof DmpComponent) {
+      // DMP component. Should listen to step changes and update text
+      const dmpComponent = componentInstance as DmpComponent;
+      this.dataInfoService = dmpComponent.instructionStep$.subscribe(value => {
+        this.greeting = this.replaceFirstname(this.name, value.greeting);
+        this.summaryLine = value.summaryLine;
+      });
+    } else if (
+      componentInstance instanceof DashboardComponent ||
+      componentInstance == null
+    ) {
+      // Dashboard or router not yet initialized
+      this.greeting =
+        this.templateDataLayout.layout.menu.greeting +
+        ' ' +
+        this.name +
+        ' ' +
+        this.templateDataLayout.layout.menu.titleDashboard;
+      this.summaryLine = 'layout.menu.section';
     }
   }
+
+  // TODO:  Update translation files to accept a parameter for strings where `Firstname` is used (https://github.com/ngx-translate/core?tab=readme-ov-file#4-define-the-translations)
+  //        Provide name to translate pipe or directive.
+  //        Remove this method.
   replaceFirstname(name: string, str: string): string {
     const regex = new RegExp(`\\b${'Firstname'}\\b`, 'g');
     if (regex.test(str)) {

--- a/libs/damap/src/index.ts
+++ b/libs/damap/src/index.ts
@@ -3,6 +3,7 @@ export * from './lib/damap.module';
 export * from './lib/testing/translate-testing/translate-testing.module';
 export * from './lib/widgets/env-banner/env-banner.module';
 export * from './lib/widgets/env-banner/env-banner.component';
+export * from './lib/components/dashboard';
 export * from './lib/components/dmp/dmp.module';
 
 export * from './lib/store/damap-store.module';

--- a/libs/damap/src/lib/components/dashboard/dashboard.component.ts
+++ b/libs/damap/src/lib/components/dashboard/dashboard.component.ts
@@ -1,9 +1,8 @@
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],

--- a/libs/damap/src/lib/components/dashboard/index.ts
+++ b/libs/damap/src/lib/components/dashboard/index.ts
@@ -1,0 +1,2 @@
+export * from './dashboard.component';
+export * from './dashboard.module';

--- a/libs/damap/src/lib/components/dmp/dmp.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.spec.ts
@@ -20,7 +20,7 @@ import { of, Subject } from 'rxjs';
 import { mockContributor1 } from '../../mocks/contributor-mocks';
 import { configMockData } from '../../mocks/config-service-mocks';
 import { Config } from '../../domain/config';
-import { NO_ERRORS_SCHEMA, ChangeDetectionStrategy } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('DmpComponent', () => {
   let component: DmpComponent;
@@ -76,11 +76,7 @@ describe('DmpComponent', () => {
         { provide: BackendService, useValue: backendSpy },
         { provide: FeedbackService, useValue: feedbackSpy },
       ],
-    })
-      .overrideComponent(DmpComponent, {
-        set: { changeDetection: ChangeDetectionStrategy.OnPush },
-      })
-      .compileComponents();
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -1,12 +1,5 @@
 import { ActivatedRoute, Router } from '@angular/router';
-import {
-  Component,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-  ChangeDetectorRef,
-  ChangeDetectionStrategy,
-} from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import {
@@ -39,7 +32,6 @@ import { InfoLabelService } from '../../services/infoLabel.service';
 import { InfoBoxDetails } from '../../domain/infoBox-details';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-dmp',
   templateUrl: './dmp.component.html',
   styleUrls: ['./dmp.component.css'],
@@ -92,7 +84,6 @@ export class DmpComponent implements OnInit, OnDestroy {
     private backendService: BackendService,
     public store: Store<AppState>,
     private infoLabelService: InfoLabelService,
-    private cdr: ChangeDetectorRef,
   ) {
     this.dmpForm = this.formService.dmpForm;
   }

--- a/libs/damap/src/lib/components/plans/plans.component.ts
+++ b/libs/damap/src/lib/components/plans/plans.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { deleteDmp, loadDmps } from '../../store/actions/dmp.actions';
 import {
@@ -20,7 +20,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-plan',
   templateUrl: './plans.component.html',
   styleUrls: ['./plans.component.css'],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

#### What does this PR do?
Use default change detection for components.
For tables, no change was detected when updating data in the background. It would have required a manual push to render again.

#### Breaking changes



#### Code review focus



#### Dependencies



### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes #333 
