### PR TITLE
Global: Update tables, search fields and form-fields

### DIFF
--- a/apps/damap-frontend/src/app/app.module.ts
+++ b/apps/damap-frontend/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { OAuthModule } from 'angular-oauth2-oidc';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { environment } from '../environments/environment';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 // required for AOT compilation
 export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
@@ -77,6 +78,10 @@ export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
         configService.initializeApp(),
       multi: true,
       deps: [ConfigService],
+    },
+    {
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
+      useValue: { appearance: 'outline' },
     },
     AuthGuard,
     ConsentGuard,

--- a/apps/damap-frontend/src/styles.scss
+++ b/apps/damap-frontend/src/styles.scss
@@ -27,6 +27,15 @@
       $app-light-theme,
       on-secondary-container
     )};
+  --secondary-fixed-dim: #{mat.get-theme-color(
+      $app-light-theme,
+      secondary-fixed-dim
+    )};
+  --tertiary: #{mat.get-theme-color($app-light-theme, tertiary)};
+  --tertiary-container: #{mat.get-theme-color(
+      $app-light-theme,
+      tertiary-container
+    )};
   --tertiary-color-very-light: #{mat.get-theme-color(
       $app-light-theme,
       tertiary,
@@ -37,6 +46,10 @@
   --surface-container-low: #{mat.get-theme-color(
       $app-light-theme,
       surface-container-low
+    )};
+  --surface-container-lowest: #{mat.get-theme-color(
+      $app-light-theme,
+      surface-container-lowest
     )};
   --surface-container-high: #{mat.get-theme-color(
       $app-light-theme,
@@ -88,6 +101,20 @@
       font
     )};
 
+  --body-large-typography: #{mat.get-theme-typography(
+      $app-light-theme,
+      body-large,
+      font
+    )};
+
+  --title-medium-typography: #{mat.get-theme-typography(
+      $app-light-theme,
+      title-medium,
+      font
+    )};
+
+  --title-large: #{mat.get-theme-typography($app-light-theme, title-large, font)};
+
   --body-large: #{mat.get-theme-typography($app-light-theme, body-large, font)};
 
   --display-large: #{mat.get-theme-typography(
@@ -101,6 +128,4 @@
       display-medium,
       font
     )};
-
-  --title-large: #{mat.get-theme-typography($app-light-theme, title-large, font)};
 }

--- a/apps/damap-frontend/src/themes/custom-theme.scss
+++ b/apps/damap-frontend/src/themes/custom-theme.scss
@@ -194,7 +194,7 @@ html {
   --mdc-text-button-label-text-weight: bold;
 }
 
-// only works for mat-raised-button
+// only works for mat-raised-button, since they are the most used button in the application by far
 .button-color-primary {
   --mdc-protected-button-container-color: var(--primary);
   --mdc-protected-button-label-text-color: var(--on-primary);
@@ -221,3 +221,17 @@ html {
 .mat-sidenav-divider-grey {
   --mat-sidenav-container-divider-color: var(--outline-variant);
 }
+
+.mat-menu-secondary-container {
+  --mat-menu-container-color: var(--secondary-container);
+  --mat-menu-item-label-text-color: var(--on-secondary-container);
+}
+
+// custom component densities (density defines the size of material components)
+.mat-textarea-density {
+  @include mat.form-field-density(-1);
+  @include mat.input-density(-1);
+}
+@include mat.form-field-density(-4);
+@include mat.input-density(-4);
+@include mat.select-density(-4);

--- a/libs/damap/src/assets/i18n/plans/de.json
+++ b/libs/damap/src/assets/i18n/plans/de.json
@@ -10,7 +10,8 @@
     "table": {
       "header": {
         "title": "Titel",
-        "version": "Version #",
+        "version": "Version",
+        "version_tag": "Versionsnummer",
         "version_name": "Versionsname",
         "created": "Erstellt",
         "modified": "Zuletzt geändert",

--- a/libs/damap/src/assets/i18n/plans/en.json
+++ b/libs/damap/src/assets/i18n/plans/en.json
@@ -11,8 +11,9 @@
     "table": {
       "header": {
         "title": "Title",
-        "version": "Version #",
-        "version_name": "Version Name",
+        "version": "Version",
+        "version_tag": "version tag",
+        "version_name": "version name",
         "created": "Created",
         "modified": "Last modified",
         "contact": "Contact"

--- a/libs/damap/src/assets/styles.scss
+++ b/libs/damap/src/assets/styles.scss
@@ -62,11 +62,6 @@ mat-card {
   width: 100%;
 }
 
-.wrap-normal-label {
-  white-space: normal;
-  height: auto;
-}
-
 .flex-radio {
   display: flex;
   flex-direction: column;
@@ -145,4 +140,56 @@ mat-card {
 .mat-icon-shadow:hover {
   transform: scale(1.005) translateZ(0);
   box-shadow: 0px 0px 15px 10px rgba(246, 246, 246, 1);
+}
+
+.zebra-table {
+  & tbody tr:not(.expanded-row):hover {
+    background: var(--secondary-container);
+    color: var(--on-secondary-container);
+  }
+
+  & tbody tr:not(.expanded-row):active {
+    background: var(--secondary-fixed-dim);
+  }
+
+  & tbody tr:nth-child(odd) {
+    background-color: var(--surface-container-low);
+  }
+
+  .mat-mdc-cell {
+    border-bottom: none;
+  }
+}
+
+.mat-mdc-form-field {
+  .mdc-notched-outline__leading,
+  .mdc-notched-outline__notch,
+  .mdc-notched-outline__trailing {
+    border-width: 1px !important;
+    border-color: var(--primary) !important;
+  }
+}
+
+.mat-mdc-form-field.mat-focused {
+  .mdc-notched-outline__leading,
+  .mdc-notched-outline__trailing {
+    border-width: 2px !important;
+    border-color: var(--primary) !important;
+  }
+
+  .mdc-notched-outline__notch {
+    border-right-width: 1px !important;
+    border-left-width: 1px !important;
+    border-bottom-width: 2px !important;
+    border-top-width: 2px !important;
+    border-color: var(--primary) !important;
+  }
+}
+
+// Angular material labels are bugged for the outline appearance of formfields
+// they dont reserve space above, so in combination with other components, the labels are cut off
+// this should offset the bug, and should be removed when the bug is fixed
+mat-dialog-content mat-form-field,
+mat-tab-body mat-form-field {
+  margin-top: 5px !important;
 }

--- a/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.html
+++ b/libs/damap/src/lib/components/dmp/data-deletion/data-deletion.component.html
@@ -38,10 +38,10 @@
         <mat-datepicker #picker></mat-datepicker>
       </mat-form-field>
     </div>
-    <app-input-wrapper
+    <app-textarea-wrapper
       [label]="'dmp.steps.data.deletion.question.reason'"
       [control]="reasonForDeletion"
       [maxLength]="4000">
-    </app-input-wrapper>
+    </app-textarea-wrapper>
   </div>
 </div>

--- a/libs/damap/src/lib/components/dmp/data-storage/data-access/data-access.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/data-access/data-access.component.html
@@ -19,7 +19,7 @@
             <div class="one">
               {{ dataset.value.title }}
             </div>
-            <mat-form-field appearance="fill" class="two">
+            <mat-form-field class="two">
               <mat-label>{{
                 "dmp.steps.data.access.question.right" | translate
               }}</mat-label>
@@ -36,7 +36,7 @@
                 </mat-option>
               </mat-select>
             </mat-form-field>
-            <mat-form-field appearance="fill" class="three">
+            <mat-form-field class="three">
               <mat-label>{{
                 "dmp.steps.data.access.question.right" | translate
               }}</mat-label>
@@ -53,7 +53,7 @@
                 </mat-option>
               </mat-select>
             </mat-form-field>
-            <mat-form-field appearance="fill" class="four">
+            <mat-form-field class="four">
               <mat-label>{{
                 "dmp.steps.data.access.question.right" | translate
               }}</mat-label>

--- a/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
@@ -82,8 +82,7 @@
       [style]="'margin: 5px;'">
       <app-textarea-wrapper
         [label]="'dmp.steps.storage.external.question.info'"
-        [control]="externalStorageInfo"
-        [appearance]="'fill'">
+        [control]="externalStorageInfo">
       </app-textarea-wrapper>
     </div>
   </div>

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
@@ -13,7 +13,7 @@ import {
 import { AppState } from '../../../store/states/app.state';
 import { ETemplateType } from '../../../domain/enum/export-template-type.enum';
 import { ExportWarningDialogComponent } from '../../../widgets/export-warning-dialog/export-warning-dialog.component';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, UntypedFormControl } from '@angular/forms';
 import { FormService } from '../../../services/form.service';
 import { selectDmpSaving } from '../../../store/selectors/dmp.selectors';
 import {
@@ -109,7 +109,7 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
             versionName,
           }),
         );
-      } else {
+      } else if (versionName.length > 255) {
         this.feedbackService.error('Version name is too long');
       }
     });
@@ -181,10 +181,15 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
 })
 export class SaveVersionDialogComponent {
   versionName = '';
+  mockControl = new UntypedFormControl();
 
   constructor(public dialogRef: MatDialogRef<SaveVersionDialogComponent>) {}
 
   onNoClick(): void {
     this.dialogRef.close();
+  }
+
+  readInput(input: string): void {
+    this.versionName = input;
   }
 }

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.module.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.module.ts
@@ -14,6 +14,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { SaveStatusModule } from '../../../widgets/save-status/save-status.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { SharedModule } from '../../../shared/shared.module';
 import { LivePreviewModule } from '../live-preview/live-preview.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
@@ -35,6 +36,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     TranslateModule,
     RouterModule,
     SaveStatusModule,
+    SharedModule,
     LivePreviewModule,
 
     // Materials

--- a/libs/damap/src/lib/components/dmp/dmp-actions/save-version-dialog.html
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/save-version-dialog.html
@@ -1,10 +1,11 @@
 <h1 mat-dialog-title>{{'dmp.dialog.title' | translate}}</h1>
 <mat-dialog-content>
   <p>{{'dmp.dialog.description' | translate}}:</p>
-  <mat-form-field appearance="fill" [style.width.%]="100">
-    <mat-label>{{'dmp.dialog.label' | translate}}</mat-label>
-    <input matInput [(ngModel)]="versionName" />
-  </mat-form-field>
+  <app-input-wrapper
+    [label]="'dmp.dialog.label'"
+    [control]="mockControl"
+    [maxLength]="255"
+    (inputChange)="readInput($event)"></app-input-wrapper>
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button (click)="onNoClick()">

--- a/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.css
+++ b/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.css
@@ -1,8 +1,3 @@
-.wrap-label {
-  white-space: normal;
-  height: auto;
-}
-
 .full-width {
   width: 100%;
 }

--- a/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.html
+++ b/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.html
@@ -18,14 +18,11 @@
   [control]="documentation">
 </app-textarea-wrapper>
 
-<mat-form-field
-  appearance="fill"
-  [style]="'width: 100%'"
-  [formGroup]="docDataStep">
+<mat-form-field class="full-width" [formGroup]="docDataStep">
   <mat-label
     >{{ "dmp.steps.documentation.question.dataQuality" | translate }}
   </mat-label>
-  <mat-select formControlName="dataQuality" multiple #matSelect>
+  <mat-select formControlName="dataQuality" multiple>
     <mat-option
       *ngFor="let option of dataQualityOptions | keyvalue: originalOrder"
       [value]="option.key">
@@ -34,9 +31,8 @@
   </mat-select>
 </mat-form-field>
 
-<app-input-wrapper
+<app-textarea-wrapper
   *ngIf="isOtherDataQualitySelected"
-  appearance="fill"
   [maxLength]="4000"
   [label]="'dmp.steps.documentation.question.otherDataQuality'"
-  [control]="otherDataQuality"></app-input-wrapper>
+  [control]="otherDataQuality"></app-textarea-wrapper>

--- a/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.component.html
+++ b/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.component.html
@@ -44,7 +44,7 @@
       </div>
       <div>
         <div class="form-field-hint">
-          <mat-form-field appearance="fill" [style]="'width: 100%'">
+          <mat-form-field class="full-width">
             <mat-label
               >{{
                 "dmp.steps.legal.question.sensitiveDataSecurity" | translate
@@ -62,17 +62,15 @@
           </app-tooltip>
         </div>
         <ng-container *ngIf="isOtherMeasureSelected">
-          <app-input-wrapper
+          <app-textarea-wrapper
             [label]="'dmp.steps.legal.question.otherDataSecurityMeasures'"
             [control]="otherDataSecurityMeasures"
-            [maxLength]="4000"
-            appearance="fill"></app-input-wrapper>
+            [maxLength]="4000"></app-textarea-wrapper>
         </ng-container>
-        <app-input-wrapper
+        <app-textarea-wrapper
           [label]="'dmp.steps.legal.question.sensitiveDataAccess'"
           [control]="sensitiveDataAccess"
-          [maxLength]="4000"
-          appearance="fill"></app-input-wrapper>
+          [maxLength]="4000"></app-textarea-wrapper>
       </div>
     </ng-container>
     <hr />
@@ -117,7 +115,7 @@
         </section>
       </div>
       <div>
-        <mat-form-field appearance="fill" [style]="'width: 100%'">
+        <mat-form-field class="full-width">
           <mat-label>{{
             "dmp.steps.legal.question.personalDataCompliance" | translate
           }}</mat-label>
@@ -134,11 +132,10 @@
         </mat-form-field>
         <br /><br />
         <ng-container *ngIf="isOtherSelected">
-          <app-input-wrapper
+          <app-textarea-wrapper
             [label]="'dmp.steps.legal.question.otherPersonalDataCompliance'"
             [control]="otherPersonalDataCompliance"
-            appearance="fill"
-            [maxLength]="4000"></app-input-wrapper>
+            [maxLength]="4000"></app-textarea-wrapper>
         </ng-container>
       </div>
     </ng-container>
@@ -168,13 +165,12 @@
         </section>
       </div>
       <div>
-        <app-input-wrapper
+        <app-textarea-wrapper
           [label]="'dmp.steps.legal.question.legalRestrictionsComment'"
-          appearance="fill"
           [control]="legalRestrictionsComment"
-          [maxLength]="4000"></app-input-wrapper>
+          [maxLength]="4000"></app-textarea-wrapper>
       </div>
-      <mat-form-field appearance="fill" [style]="'width: 100%'">
+      <mat-form-field class="full-width">
         <mat-label>{{
           "dmp.steps.legal.question.legalRestrictionsDocuments" | translate
         }}</mat-label>
@@ -187,20 +183,18 @@
         </mat-select>
       </mat-form-field>
       <ng-container *ngIf="isOtherDocumentSelected">
-        <app-input-wrapper
+        <app-textarea-wrapper
           [label]="'dmp.steps.legal.question.otherLegalRestrictionsDocuments'"
           [maxLength]="4000"
-          appearance="fill"
-          [control]="otherLegalRestrictionsDocuments"></app-input-wrapper>
+          [control]="otherLegalRestrictionsDocuments"></app-textarea-wrapper>
       </ng-container>
     </ng-container>
     <hr *ngIf="!last" />
   </div>
-  <app-input-wrapper
+  <app-textarea-wrapper
     [label]="'dmp.steps.legal.question.dataRightsAndAccessControl'"
     [maxLength]="4000"
-    appearance="fill"
-    [control]="dataRightsAndAccessControl"></app-input-wrapper>
+    [control]="dataRightsAndAccessControl"></app-textarea-wrapper>
 </div>
 
 <app-ethical-aspects

--- a/libs/damap/src/lib/components/dmp/licenses/licenses.component.css
+++ b/libs/damap/src/lib/components/dmp/licenses/licenses.component.css
@@ -28,18 +28,12 @@
   margin-top: 0.5rem;
 }
 
-.custom-style ::ng-deep .mat-mdc-text-field-wrapper {
-  background-color: var(--primary);
-  background-image: linear-gradient(
-    rgba(255, 255, 255, 0.9),
-    rgba(255, 255, 255, 0.9)
-  );
-  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.3);
-  padding-left: 15px;
-}
-
 .icon-size {
   font-size: 20px;
   height: 20px;
   width: 20px;
+}
+
+.no-resize {
+  resize: none;
 }

--- a/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
+++ b/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
@@ -103,33 +103,21 @@
 <div [style.margin.px]="'5'">
   <div [formGroup]="dmpForm">
     <ng-container *ngIf="restricted?.length > 0">
-      <mat-form-field class="full-width custom-style">
-        <mat-label class="wrap-normal-label"
-          >{{ "dmp.steps.licensing.question.restrictedAccessInfo" | translate }}
-          <ng-container *ngFor="let set of restricted; last as last">
-            "{{ set.title }}"<span *ngIf="!last">, </span>.
-          </ng-container>
-        </mat-label>
-        <textarea
-          matInput
-          formControlName="restrictedAccessInfo"
-          [maxLength]="4000"></textarea>
-      </mat-form-field>
+      <app-textarea-wrapper
+        [label]="'dmp.steps.licensing.question.restrictedAccessInfo'"
+        [labelDatasets]="restricted"
+        [control]="restrictedAccessInfo"
+        [maxLength]="4000">
+      </app-textarea-wrapper>
     </ng-container>
 
     <ng-container *ngIf="closed?.length > 0">
-      <mat-form-field class="full-width custom-style">
-        <mat-label class="wrap-normal-label"
-          >{{ "dmp.steps.licensing.question.closedAccessInfo" | translate }}
-          <span *ngFor="let set of closed; last as last">
-            "{{ set.title }}"<span *ngIf="!last">, </span>.
-          </span>
-        </mat-label>
-        <textarea
-          matInput
-          formControlName="closedAccessInfo"
-          [maxLength]="4000"></textarea>
-      </mat-form-field>
+      <app-textarea-wrapper
+        [label]="'dmp.steps.licensing.question.closedAccessInfo'"
+        [labelDatasets]="closed"
+        [control]="closedAccessInfo"
+        [maxLength]="4000">
+      </app-textarea-wrapper>
     </ng-container>
   </div>
 </div>

--- a/libs/damap/src/lib/components/dmp/licenses/licenses.component.ts
+++ b/libs/damap/src/lib/components/dmp/licenses/licenses.component.ts
@@ -1,5 +1,9 @@
 import { Component, Input } from '@angular/core';
-import { UntypedFormArray, UntypedFormGroup } from '@angular/forms';
+import {
+  UntypedFormArray,
+  UntypedFormControl,
+  UntypedFormGroup,
+} from '@angular/forms';
 
 import { ComplianceType } from '../../../domain/enum/compliance-type.enum';
 import { DataAccessType } from '../../../domain/enum/data-access-type.enum';
@@ -59,5 +63,13 @@ export class LicensesComponent {
 
   getFormGroup(index: number): UntypedFormGroup {
     return this.datasets.at(index) as UntypedFormGroup;
+  }
+
+  get restrictedAccessInfo(): UntypedFormControl {
+    return this.dmpForm.get('restrictedAccessInfo') as UntypedFormControl;
+  }
+
+  get closedAccessInfo(): UntypedFormControl {
+    return this.dmpForm.get('closedAccessInfo') as UntypedFormControl;
   }
 }

--- a/libs/damap/src/lib/components/dmp/people/people.component.html
+++ b/libs/damap/src/lib/components/dmp/people/people.component.html
@@ -32,7 +32,7 @@
                   "></app-orcid>
               </div>
               <div [formGroupName]="i">
-                <mat-form-field appearance="fill">
+                <mat-form-field>
                   <mat-label>{{
                     "dmp.steps.people.contributor.role" | translate
                   }}</mat-label>
@@ -120,7 +120,7 @@
         </app-person-search>
       </div>
       <div class="service-select-container">
-        <mat-form-field appearance="fill">
+        <mat-form-field appearance="outline">
           <mat-label>{{
             "dmp.steps.people.search.service" | translate
           }}</mat-label>

--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
@@ -12,7 +12,7 @@
       label="{{
         'dmp.steps.project.input.acronym' | translate
       }}"></app-input-wrapper>
-    <mat-form-field appearance="fill" class="input-fill">
+    <mat-form-field class="input-fill">
       <mat-label>{{ "dmp.steps.project.input.date" | translate }}</mat-label>
       <mat-date-range-input [formGroup]="form" [rangePicker]="picker">
         <input matStartDate formControlName="start" placeholder="Start date" />

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.html
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.html
@@ -1,14 +1,8 @@
 <p *ngIf="!selectedProject" translate>dmp.steps.project.select</p>
 <ng-container *ngIf="!selectedProject">
-  <mat-form-field>
-    <mat-label translate>dmp.steps.project.search</mat-label>
-    <input
-      #searchBox
-      type="search"
-      matInput
-      (input)="search(searchBox.value)" />
-    <mat-icon matSuffix>search</mat-icon>
-  </mat-form-field>
+  <app-search-field
+    [label]="'dmp.steps.project.search' | translate"
+    (searchChange)="search($event)"></app-search-field>
   <div class="list-container" *ngIf="!selectedProject">
     <mat-selection-list
       hideSingleSelectionIndicator

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.spec.ts
@@ -26,6 +26,7 @@ import { TranslateTestingModule } from '../../../../testing/translate-testing/tr
 import { mockProject } from '../../../../mocks/project-mocks';
 import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { SearchFieldComponent } from '../../../../shared/search-field/search-field.component';
 
 describe('ProjectListComponent', () => {
   let component: ProjectListComponent;
@@ -56,7 +57,7 @@ describe('ProjectListComponent', () => {
         NoopAnimationsModule,
       ],
       schemas: [NO_ERRORS_SCHEMA],
-      declarations: [ProjectListComponent],
+      declarations: [ProjectListComponent, SearchFieldComponent],
       providers: [{ provide: BackendService, useValue: backendSpy }],
     }).compileComponents();
 

--- a/libs/damap/src/lib/components/dmp/project/project.module.ts
+++ b/libs/damap/src/lib/components/dmp/project/project.module.ts
@@ -10,7 +10,10 @@ import { ManualProjectInputComponent } from './manual-project-input/manual-proje
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatFormFieldModule } from '@angular/material/form-field';
+import {
+  MAT_FORM_FIELD_DEFAULT_OPTIONS,
+  MatFormFieldModule,
+} from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -81,6 +84,10 @@ import {
       deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS],
     },
     { provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS },
+    {
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
+      useValue: { appearance: 'outline' },
+    },
   ],
 })
 export class ProjectModule {}

--- a/libs/damap/src/lib/components/dmp/repo/repo-table/repo-table.component.html
+++ b/libs/damap/src/lib/components/dmp/repo/repo-table/repo-table.component.html
@@ -1,13 +1,8 @@
 <div class="repo-search-bar">
-  <mat-form-field>
-    <mat-label>{{ "dmp.steps.repositories.search" | translate }}</mat-label>
-    <input
-      matInput
-      (keyup)="applyFilter($event)"
-      placeholder="Search repository"
-      #input />
-  </mat-form-field>
-
+  <app-search-field
+    [label]="'dmp.steps.repositories.filters'"
+    [placeholder]="'Search Repository'"
+    (searchChange)="applyFilter($event)"></app-search-field>
   <div>
     <button
       mat-raised-button
@@ -111,11 +106,11 @@
       class="detail-row"></tr>
     <!-- Row shown when there is no matching data. -->
     <tr class="mat-row" *matNoDataRow>
-      <ng-container *ngIf="input.value.length > 0; else empty">
+      <ng-container *ngIf="this.input.length > 0; else empty">
         <td class="mat-cell" colspan="4">
           {{
             "dmp.steps.repositories.nodatafilter"
-              | translate: { value: input.value }
+              | translate: { value: this.input }
           }}"
         </td>
       </ng-container>

--- a/libs/damap/src/lib/components/dmp/repo/repo-table/repo-table.component.ts
+++ b/libs/damap/src/lib/components/dmp/repo/repo-table/repo-table.component.ts
@@ -53,6 +53,7 @@ export class RepoTableComponent implements OnChanges, AfterViewInit {
   readonly tableHeaders: string[] = ['expand', 'title', 'add'];
   expandedElement: string | null;
   dataSource = new MatTableDataSource<RepositoryDetails>();
+  input: string = '';
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
 
@@ -81,8 +82,8 @@ export class RepoTableComponent implements OnChanges, AfterViewInit {
   }
 
   // Table Search Filter
-  applyFilter(event: Event) {
-    const filterValue = (event.target as HTMLInputElement).value;
+  applyFilter(filterValue: string) {
+    this.input = filterValue;
     this.dataSource.filter = filterValue.trim().toLowerCase();
 
     if (this.dataSource.paginator) {

--- a/libs/damap/src/lib/components/dmp/repo/repo.module.ts
+++ b/libs/damap/src/lib/components/dmp/repo/repo.module.ts
@@ -32,6 +32,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { TagModule } from '../../../widgets/tag/tag.module';
 import { InfoMessageModule } from '../../../widgets/info-message/info-message.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { SharedModule } from '../../../shared/shared.module';
 
 @NgModule({
   imports: [
@@ -44,6 +45,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     DatasetSourceModule,
     TagModule,
     InfoMessageModule,
+    SharedModule,
 
     // Materials
     MatCardModule,
@@ -81,6 +83,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     DatasetSourceModule,
     TagModule,
     RepoComponent,
+    SharedModule,
 
     // Materials
     MatCardModule,

--- a/libs/damap/src/lib/components/dmp/reuse/reuse.component.css
+++ b/libs/damap/src/lib/components/dmp/reuse/reuse.component.css
@@ -1,8 +1,3 @@
-.wrap-label {
-  white-space: normal;
-  height: auto;
-}
-
 .full-width {
   width: 100%;
 }

--- a/libs/damap/src/lib/components/dmp/reuse/reuse.component.html
+++ b/libs/damap/src/lib/components/dmp/reuse/reuse.component.html
@@ -2,22 +2,18 @@
   <app-textarea-wrapper
     [label]="'dmp.steps.data.reuse.question.targetAudience'"
     [control]="targetAudience"
-    [showLength]="false"
-    [minRows]="2"
-    [maxRows]="6"
     [autocompleteOptions]="optionsTargetAudience">
   </app-textarea-wrapper>
 
-  <mat-form-field class="full-width" appearance="fill">
-    <mat-label class="wrap-label"
-      >{{ "dmp.steps.data.reuse.question.tools" | translate }}
-    </mat-label>
-    <textarea matInput formControlName="tools" [maxLength]="4000"></textarea>
-  </mat-form-field>
+  <app-textarea-wrapper
+    [label]="'dmp.steps.data.reuse.question.tools'"
+    [control]="tools"
+    [maxLength]="4000">
+  </app-textarea-wrapper>
 
   <ng-container *ngIf="restricted?.length > 0">
-    <mat-form-field class="full-width" appearance="fill">
-      <mat-label class="wrap-label">
+    <mat-form-field class="full-width">
+      <mat-label>
         {{ "dmp.steps.data.reuse.question.restrictedDataAccess" | translate }}
         <span *ngFor="let set of restricted; last as last">
           "{{ set.title }}"<span *ngIf="!last">, </span>.

--- a/libs/damap/src/lib/components/dmp/reuse/reuse.component.ts
+++ b/libs/damap/src/lib/components/dmp/reuse/reuse.component.ts
@@ -35,4 +35,8 @@ export class ReuseComponent {
   get targetAudience() {
     return this.reuseStep.get('targetAudience') as UntypedFormControl;
   }
+
+  get tools() {
+    return this.reuseStep.get('tools') as UntypedFormControl;
+  }
 }

--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.css
@@ -8,14 +8,6 @@ tr.detail-row {
   height: 0;
 }
 
-tr.element-row:not(.expanded-row):hover {
-  background: var(--surface-container-low);
-}
-
-tr.element-row:not(.expanded-row):active {
-  background: var(--surface-container-high);
-}
-
 .element-row td {
   border-bottom-width: 0;
 }

--- a/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/dataset-table/dataset-table.component.html
@@ -6,7 +6,7 @@
     mat-table
     [dataSource]="datasets.value | datasetSource: sourceType"
     multiTemplateDataRows="true"
-    class="mat-elevation-z8"
+    class="mat-elevation-z8 zebra-table"
     aria-label="{{ tableHeading | translate }}">
     <ng-container matColumnDef="dataset">
       <th mat-header-cell *matHeaderCellDef>

--- a/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.html
@@ -38,7 +38,6 @@
       specifyDataStep.value['reusedKind'] === dataKind.SPECIFY
     ">
     <app-textarea-wrapper
-      [applyCustomStyle]="true"
       [label]="'dmp.steps.documentation.question.datageneration'"
       [control]="dataGeneration">
     </app-textarea-wrapper>

--- a/libs/damap/src/lib/components/plans/plans.component.html
+++ b/libs/damap/src/lib/components/plans/plans.component.html
@@ -1,17 +1,11 @@
 <app-info-card></app-info-card>
 <div id="content" style="max-width: 1440px">
   <h2 translate>plans.mydmps</h2>
-  <button
-    class="button-position button-color-primary"
-    [routerLink]="'/dmp'"
-    mat-raised-button>
-    <mat-icon>add</mat-icon>
-    {{ "plans.create.dmp" | translate }}
-  </button>
 
-  <div *ngIf="(dmpsLoaded$ | async) === LoadingState.LOADED">
+  <div>
     <app-dmp-table
       [dmps]="dmps$ | async"
+      [dmpsLoaded]="dmpsLoaded$"
       (createDocument)="getDocument($event)"
       (createJsonFile)="getJsonFile($event)"
       (dmpToDelete)="deleteDmp($event)"></app-dmp-table>
@@ -29,6 +23,7 @@
     <h2 translate>plans.alldmps</h2>
     <app-dmp-table
       [dmps]="allDmps$ | async"
+      [dmpsLoaded]="dmpsLoaded$"
       (createDocument)="getDocument($event)"
       [admin]="true"
       (createJsonFile)="getJsonFile($event)"

--- a/libs/damap/src/lib/components/plans/plans.component.spec.ts
+++ b/libs/damap/src/lib/components/plans/plans.component.spec.ts
@@ -93,7 +93,7 @@ describe('PlansComponent', () => {
     expect(dialogs.length).toBe(1);
 
     const buttons = await loader.getAllHarnesses(MatButtonHarness);
-    await buttons[2].click();
+    await buttons[1].click();
 
     expect(backendSpy.deleteDmp).toHaveBeenCalledWith(1);
     expect(store.dispatch).toHaveBeenCalledTimes(1);

--- a/libs/damap/src/lib/components/version/version-table/version-table.component.html
+++ b/libs/damap/src/lib/components/version/version-table/version-table.component.html
@@ -8,7 +8,11 @@
   </button>
 </div>
 <div class="mat-elevation-z8" *ngIf="versions">
-  <table mat-table [dataSource]="versions" aria-label="DMP Versions">
+  <table
+    mat-table
+    [dataSource]="versions"
+    aria-label="DMP Versions"
+    class="zebra-table">
     <!-- Version Column -->
     <ng-container matColumnDef="version">
       <th mat-header-cell *matHeaderCellDef>

--- a/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.html
+++ b/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.html
@@ -1,6 +1,6 @@
 <mat-form-field [appearance]="appearance">
-  <mat-label class="wrap-label"
-    >{{ label | translate }}
+  <mat-label>
+    {{ label | translate }}
     <app-tooltip *ngIf="info?.length" [tooltip]="info"></app-tooltip>
   </mat-label>
   <span matTextPrefix>{{ prefix }}</span>
@@ -12,6 +12,7 @@
     [required]="required"
     [step]="type === 'number' ? 0.01 : null"
     [maxLength]="maxLength"
+    (input)="onInputChange(message.value)"
     #message />
   <mat-hint align="end">{{ message.value.length }} / {{ maxLength }}</mat-hint>
   <mat-error *ngIf="!control?.errors?.required && control?.errors?.empty">

--- a/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.ts
+++ b/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
 
@@ -13,13 +13,18 @@ export class InputWrapperComponent implements OnInit {
   @Input() prefix: string;
   @Input() type: string;
   @Input() placeholder: string;
-  @Input() appearance: MatFormFieldAppearance = 'fill';
+  @Input() appearance: MatFormFieldAppearance = 'outline';
   @Input() maxLength = 255;
   @Input() info: string;
+  @Output() inputChange: EventEmitter<string> = new EventEmitter<string>();
 
   required = false;
 
   ngOnInit(): void {
     this.required = this.control?.hasValidator(Validators.required);
+  }
+
+  onInputChange(value: string): void {
+    this.inputChange.emit(value);
   }
 }

--- a/libs/damap/src/lib/shared/search-field/search-field.component.css
+++ b/libs/damap/src/lib/shared/search-field/search-field.component.css
@@ -1,0 +1,7 @@
+.search-field {
+  width: inherit;
+}
+
+.focus-icon.mat-focused {
+  --mat-form-field-trailing-icon-color: var(--primary);
+}

--- a/libs/damap/src/lib/shared/search-field/search-field.component.html
+++ b/libs/damap/src/lib/shared/search-field/search-field.component.html
@@ -1,0 +1,15 @@
+<mat-form-field [appearance]="appearance" class="search-field focus-icon">
+  <!-- translate has to happen here, if it is done outside label is rendered as empty string always-->
+  <mat-label *ngIf="label">{{ label | translate }}</mat-label>
+  <input
+    type="search"
+    matInput
+    placeholder="{{ placeholder }}"
+    [formControl]="control"
+    (input)="onSearchChange(input.value)"
+    #input />
+  <mat-icon matIconSuffix>search</mat-icon>
+  <mat-error *ngIf="errorMessage">
+    {{ errorMessage | translate }}
+  </mat-error>
+</mat-form-field>

--- a/libs/damap/src/lib/shared/search-field/search-field.component.spec.ts
+++ b/libs/damap/src/lib/shared/search-field/search-field.component.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SearchFieldComponent } from './search-field.component';
+import { SharedModule } from '../shared.module';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { TranslateTestingModule } from '../../testing/translate-testing/translate-testing.module';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+fdescribe('SearchFieldComponent', () => {
+  let component: SearchFieldComponent;
+  let fixture: ComponentFixture<SearchFieldComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        SharedModule,
+        MatFormFieldModule,
+        TranslateTestingModule,
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+      ],
+      declarations: [SearchFieldComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchFieldComponent);
+    component = fixture.componentInstance;
+    component.control = new UntypedFormControl('');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit searchChange on input', () => {
+    spyOn(component.searchChange, 'emit');
+
+    const testValue = 'test search';
+    component.control.setValue(testValue);
+
+    component.onSearchChange(testValue);
+
+    expect(component.searchChange.emit).toHaveBeenCalledWith(testValue);
+  });
+
+  it('should display the correct placeholder', () => {
+    component.placeholder = 'Search here';
+    fixture.detectChanges();
+
+    const inputEl: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    expect(inputEl.placeholder).toBe('Search here');
+  });
+
+  it('should display the correct label', () => {
+    component.placeholder = 'Search here';
+    fixture.detectChanges();
+
+    const inputEl: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    expect(inputEl.placeholder).toBe('Search here');
+  });
+});

--- a/libs/damap/src/lib/shared/search-field/search-field.component.ts
+++ b/libs/damap/src/lib/shared/search-field/search-field.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatFormFieldAppearance } from '@angular/material/form-field';
+import { UntypedFormControl } from '@angular/forms';
+
+@Component({
+  selector: 'app-search-field',
+  templateUrl: './search-field.component.html',
+  styleUrl: './search-field.component.css',
+})
+export class SearchFieldComponent {
+  @Input() label: string = '';
+  @Input() placeholder: string = '';
+  @Input() appearance: MatFormFieldAppearance = 'outline';
+  @Input() control: UntypedFormControl = new UntypedFormControl();
+  @Input() errorMessage: string = '';
+  @Output() searchChange: EventEmitter<string> = new EventEmitter<string>();
+
+  onSearchChange(value: string): void {
+    this.searchChange.emit(value);
+  }
+}

--- a/libs/damap/src/lib/shared/shared.module.ts
+++ b/libs/damap/src/lib/shared/shared.module.ts
@@ -8,9 +8,15 @@ import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { TooltipModule } from '../widgets/tooltip/tooltip.module';
+import { SearchFieldComponent } from './search-field/search-field.component';
+import { MatIconButton } from '@angular/material/button';
 
 @NgModule({
-  declarations: [InputWrapperComponent, TextareaWrapperComponent],
+  declarations: [
+    InputWrapperComponent,
+    TextareaWrapperComponent,
+    SearchFieldComponent,
+  ],
   imports: [
     CommonModule,
     FormsModule,
@@ -22,6 +28,7 @@ import { TooltipModule } from '../widgets/tooltip/tooltip.module';
     MatFormFieldModule,
     MatInputModule,
     MatAutocompleteModule,
+    MatIconButton,
   ],
   exports: [
     CommonModule,
@@ -31,6 +38,7 @@ import { TooltipModule } from '../widgets/tooltip/tooltip.module';
     InputWrapperComponent,
     TextareaWrapperComponent,
     TooltipModule,
+    SearchFieldComponent,
 
     // Materials
     MatFormFieldModule,

--- a/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.css
+++ b/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.css
@@ -6,15 +6,6 @@ mat-form-field {
   width: 100%;
 }
 
-.custom-style ::ng-deep .mat-mdc-text-field-wrapper {
-  background-color: var(--primary);
-  background-image: linear-gradient(
-    rgba(255, 255, 255, 0.9),
-    rgba(255, 255, 255, 0.9)
-  );
-  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.3);
-}
-
 .no-resize {
   resize: none;
 }

--- a/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.html
+++ b/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.html
@@ -1,7 +1,10 @@
-<mat-form-field
-  [appearance]="appearance"
-  [class.custom-style]="applyCustomStyle">
-  <mat-label class="wrap-label">{{ label | translate }}</mat-label>
+<mat-form-field [appearance]="appearance" class="mat-textarea-density">
+  <mat-label
+    >{{ label | translate }}
+    <ng-container *ngFor="let set of labelDatasets; last as last">
+      "{{ set.title }}"<span *ngIf="!last">, </span>.
+    </ng-container>
+  </mat-label>
 
   <ng-template #standard>
     <textarea

--- a/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.ts
+++ b/libs/damap/src/lib/shared/textarea-wrapper/textarea-wrapper.component.ts
@@ -3,7 +3,7 @@ import { UntypedFormControl, Validators } from '@angular/forms';
 
 import { MatFormFieldAppearance } from '@angular/material/form-field';
 import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
-import { ContentObserver } from '@angular/cdk/observers';
+import { Dataset } from '../../domain/dataset';
 
 @Component({
   selector: 'app-textarea-wrapper [label] [control]',
@@ -12,12 +12,12 @@ import { ContentObserver } from '@angular/cdk/observers';
 })
 export class TextareaWrapperComponent implements OnInit {
   @Input() label: string;
+  @Input() labelDatasets: Dataset[];
   @Input() control: UntypedFormControl;
   @Input() placeholder: string;
   @Input() autocompleteOptions: string[];
   @Input() appearance: MatFormFieldAppearance = 'fill';
   @Input() maxLength = 4000;
-  @Input() applyCustomStyle = false;
   @Input() showLength = true;
   @Input() minRows = 5;
   @Input() maxRows = 9;

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.css
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.css
@@ -1,85 +1,66 @@
-table {
-  width: 100%;
-}
-
-tr.detail-row {
-  height: 0;
-}
-
-tr.element-row:not(.expanded-row):hover {
-  background: var(--surface-container-low);
-}
-
-tr.element-row:not(.expanded-row):active {
-  background: var(--surface-container-high);
-}
-
-.element-detail {
-  overflow: hidden;
+.button-and-search {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-between;
+  align-content: center;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.search-bar {
+  width: 100%;
+  max-width: 435px;
+}
+
+.table-wrapper {
+  background-color: var(--mat-table-background-color);
+  padding: 16px;
+  border-radius: 16px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  overflow: auto;
+}
+
+th.mat-column-title {
+  font: var(--title-medium-typography);
+}
+
+th.mat-column-version,
+th.mat-column-created,
+th.mat-column-modified,
+th.mat-column-contact {
+  font: var(--body-large-typography);
+  text-align: left;
+}
+
+td.mat-column-version {
+  max-width: 250px;
+  min-width: 150px;
+  overflow: hidden;
 }
 
 td.mat-column-created,
 td.mat-column-modified,
 td.mat-column-contact {
-  width: 120px;
+  width: 140px;
   overflow: hidden;
 }
 
-td.mat-column-version,
-td.mat-column-version_name {
-  width: 150px;
-  overflow: hidden;
-  text-align: center;
-}
-
-.mat-column-edit {
-  width: 30px;
-}
-
-::ng-deep button.mdc-button_label {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-evenly;
-}
-
-#dmp-actions {
-  margin: 1rem 0.5rem;
-}
-
-#dmp-actions > button {
-  margin-right: 0.5rem;
-}
-
-::ng-deep .mat-mdc-menu-content {
-  display: flex;
-  flex-direction: column;
-  padding: 5px;
-  gap: 5px;
+td.mat-column-edit {
+  width: 20px;
 }
 
 a.title {
-  display: inline-flex;
-  align-items: center;
   text-decoration: none;
   color: var(--on-surface);
 }
 
 a.version {
   text-align: center;
-  color: var(--on-surface);
+  text-decoration: none;
 }
 
-button.mat-focus-indicator .mat-mdc-unelevated-button.mat-primary,
-.mat-mdc-raised-button.mat-primary,
-.mat-mdc-fab.mat-primary,
-.mat-mdc-mini-fab.mat-primary {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
+.underlined {
+  text-decoration: underline;
 }
 
 .word-break {

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
@@ -1,140 +1,153 @@
-<mat-form-field>
-  <mat-label>{{ "plans.table.search" | translate }}</mat-label>
-  <input
-    matInput
-    (keyup)="applyFilter($event)"
-    placeholder="{{ 'plans.table.search' | translate }}"
-    #input />
-</mat-form-field>
+<div class="button-and-search">
+  <button class="button-color-primary" [routerLink]="'/dmp'" mat-raised-button>
+    <mat-icon>add</mat-icon>
+    {{ "plans.create.dmp" | translate }}
+  </button>
 
-<table
-  mat-table
-  [dataSource]="dataSource"
-  multiTemplateDataRows="true"
-  class="mat-elevation-z8"
-  style="outline: none"
-  matSort
-  aria-label="Available DMPs">
-  <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>
-      {{ "plans.table.header.title" | translate }}
-    </th>
-    <td mat-cell *matCellDef="let element">
-      <a class="title" routerLink="/dmp/{{ element.id }}">
-        <h3 matTooltip="Edit DMP">
-          {{ element.project?.title || "DMP ID: " + element.id }}
-        </h3>
-      </a>
-    </td>
-  </ng-container>
+  <app-search-field
+    *ngIf="(dmpsLoaded | async) === LoadingState.LOADED"
+    class="search-bar"
+    [label]="'plans.table.search'"
+    (searchChange)="applyFilter($event)"></app-search-field>
+</div>
 
-  <ng-container matColumnDef="version">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>
-      {{ "plans.table.header.version" | translate }}
-    </th>
-    <td mat-cell *matCellDef="let element">
-      <a class="version" routerLink="/dmp/{{ element.id }}/version">
-        {{ element.versionCount !== null ? element.versionCount : 0 }}
-      </a>
-    </td>
-  </ng-container>
-
-  <ng-container matColumnDef="version_name">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>
-      {{ "plans.table.header.version_name" | translate }}
-    </th>
-    <td mat-cell *matCellDef="let element">
-      <a class="version word-break" routerLink="/dmp/{{ element.id }}/version">
-        {{ element.latestVersionName }}
-      </a>
-    </td>
-  </ng-container>
-
-  <ng-container matColumnDef="created">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>
-      {{ "plans.table.header.created" | translate }}
-    </th>
-    <td mat-cell *matCellDef="let element">{{ element.created | date }}</td>
-  </ng-container>
-
-  <ng-container matColumnDef="modified">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>
-      {{ "plans.table.header.modified" | translate }}
-    </th>
-    <td mat-cell *matCellDef="let element">{{ element.modified | date }}</td>
-  </ng-container>
-
-  <ng-container matColumnDef="contact">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>
-      {{ "plans.table.header.contact" | translate }}
-    </th>
-    <td mat-cell *matCellDef="let element">
-      <ng-container *ngIf="element.contact; else nocontact">
-        {{ element.contact?.firstName + " " + element.contact?.lastName }}
-      </ng-container>
-      <ng-template #nocontact>
-        {{ "plans.table.nocontact" | translate }}
-      </ng-template>
-    </td>
-  </ng-container>
-
-  <ng-container matColumnDef="edit" style="width: 10px">
-    <th mat-header-cell *matHeaderCellDef>
-      <span class="sr-only">{{ "plans.table.actions.edit" | translate }}</span>
-    </th>
-    <td mat-cell *matCellDef="let element">
-      <button mat-icon-button [matMenuTriggerFor]="menu">
-        <mat-icon>more_vert</mat-icon>
-      </button>
-      <mat-menu #menu="matMenu" xPosition="before">
-        <button mat-menu-item routerLink="/dmp/{{ element.id }}/access">
-          <mat-icon>admin_panel_settings</mat-icon>
-          {{ "plans.table.actions.access" | translate }}
-        </button>
-        <button mat-menu-item (click)="getJsonFile(element.id)">
-          <mat-icon>code</mat-icon>
-          {{ "plans.table.export.json" | translate }}
-        </button>
-        <button mat-menu-item (click)="getDocument(element.id)">
-          <mat-icon>description</mat-icon>
-          {{ "plans.table.export.doc" | translate }}
-        </button>
-        <button mat-menu-item routerLink="/dmp/{{ element.id }}/version">
-          <mat-icon>history</mat-icon>
-          {{ "plans.table.actions.history" | translate }}
-        </button>
-        <button
-          mat-menu-item
-          *ngIf="element.accessType === FUNCTION_ROLES.OWNER || admin"
-          (click)="deleteDmp(element.id)">
-          <mat-icon>delete</mat-icon>
-          {{ "plans.table.actions.delete" | translate }}
-        </button>
-      </mat-menu>
-    </td>
-  </ng-container>
-
-  <tr mat-header-row *matHeaderRowDef="tableHeaders"></tr>
-  <tr
-    mat-row
-    *matRowDef="let element; columns: tableHeaders"
-    class="element-row"></tr>
-  <!-- Row shown when there is no matching data. -->
-  <tr class="mat-row" *matNoDataRow>
-    <ng-container *ngIf="input.value.length > 0; else empty">
-      <td class="mat-cell" colspan="4">
-        {{ "plans.table.nodatafilter" | translate: { value: input.value } }}"
+<div class="table-wrapper" *ngIf="(dmpsLoaded | async) === LoadingState.LOADED">
+  <table
+    mat-table
+    [dataSource]="dataSource"
+    multiTemplateDataRows="true"
+    class="mat-elevation-z8 zebra-table"
+    matSort
+    aria-label="Available DMPs">
+    <ng-container matColumnDef="title">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ "plans.table.header.title" | translate }}
+      </th>
+      <td mat-cell *matCellDef="let element">
+        <a class="title" routerLink="/dmp/{{ element.id }}">
+          <h3 matTooltip="Edit DMP">
+            {{ element.project?.title || "DMP ID: " + element.id }}
+          </h3>
+        </a>
       </td>
     </ng-container>
-    <ng-template #empty>
-      <td class="mat-cell" colspan="4">
-        {{ "plans.table.empty" | translate }}
+
+    <ng-container matColumnDef="version">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ "plans.table.header.version" | translate }}
+      </th>
+      <td mat-cell *matCellDef="let element">
+        <a class="version" routerLink="/dmp/{{ element.id }}/version">
+          {{
+            element.versionCount !== null
+              ? ("plans.table.header.version_tag" | translate) + ": "
+              : ""
+          }}
+          <span class="underlined">{{
+            element.versionCount !== null ? "#" + element.versionCount : ""
+          }}</span>
+          <br />
+          {{
+            element.versionCount !== null
+              ? ("plans.table.header.version_name" | translate) + ": "
+              : ""
+          }}
+          <span class="underlined">{{
+            element.versionCount !== null ? element.latestVersionName : ""
+          }}</span>
+        </a>
       </td>
-    </ng-template>
-  </tr>
-</table>
-<mat-paginator
-  class="mat-elevation-z8"
-  [pageSize]="10"
-  [pageSizeOptions]="[10, 15, 20]"
-  showFirstLastButtons="true"></mat-paginator>
+    </ng-container>
+
+    <ng-container matColumnDef="created">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ "plans.table.header.created" | translate }}
+      </th>
+      <td mat-cell *matCellDef="let element">{{ element.created | date }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="modified">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ "plans.table.header.modified" | translate }}
+      </th>
+      <td mat-cell *matCellDef="let element">{{ element.modified | date }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="contact">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ "plans.table.header.contact" | translate }}
+      </th>
+      <td mat-cell *matCellDef="let element">
+        <ng-container *ngIf="element.contact; else nocontact">
+          {{ element.contact?.firstName + " " + element.contact?.lastName }}
+        </ng-container>
+        <ng-template #nocontact>
+          {{ "plans.table.nocontact" | translate }}
+        </ng-template>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="edit">
+      <th mat-header-cell *matHeaderCellDef>
+        <span class="sr-only">{{
+          "plans.table.actions.edit" | translate
+        }}</span>
+      </th>
+      <td mat-cell *matCellDef="let element">
+        <button mat-icon-button [matMenuTriggerFor]="menu">
+          <mat-icon>more_horiz</mat-icon>
+        </button>
+        <mat-menu
+          #menu="matMenu"
+          xPosition="before"
+          class="mat-menu-secondary-container">
+          <button mat-menu-item routerLink="/dmp/{{ element.id }}/access">
+            <mat-icon>admin_panel_settings</mat-icon>
+            {{ "plans.table.actions.access" | translate }}
+          </button>
+          <button mat-menu-item (click)="getJsonFile(element.id)">
+            <mat-icon>code</mat-icon>
+            {{ "plans.table.export.json" | translate }}
+          </button>
+          <button mat-menu-item (click)="getDocument(element.id)">
+            <mat-icon>description</mat-icon>
+            {{ "plans.table.export.doc" | translate }}
+          </button>
+          <button mat-menu-item routerLink="/dmp/{{ element.id }}/version">
+            <mat-icon>history</mat-icon>
+            {{ "plans.table.actions.history" | translate }}
+          </button>
+          <button
+            mat-menu-item
+            *ngIf="element.accessType === FUNCTION_ROLES.OWNER || admin"
+            (click)="deleteDmp(element.id)">
+            <mat-icon>delete</mat-icon>
+            {{ "plans.table.actions.delete" | translate }}
+          </button>
+        </mat-menu>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="tableHeaders"></tr>
+    <tr mat-row *matRowDef="let element; columns: tableHeaders"></tr>
+    <!-- Row shown when there is no matching data. -->
+    <tr class="mat-row" *matNoDataRow></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <ng-container *ngIf="searchTerm.length > 0; else empty">
+        <td class="mat-cell" colspan="4">
+          {{ "plans.table.nodatafilter" | translate: { value: searchTerm } }}
+        </td>
+      </ng-container>
+      <ng-template #empty>
+        <td class="mat-cell" colspan="4">
+          {{ "plans.table.empty" | translate }}
+        </td>
+      </ng-template>
+    </tr>
+  </table>
+  <mat-paginator
+    class="mat-elevation-z8"
+    [pageSize]="10"
+    [pageSizeOptions]="[10, 15, 20]"
+    showFirstLastButtons="true"></mat-paginator>
+</div>

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.ts
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.ts
@@ -15,6 +15,8 @@ import { FunctionRole } from '../../domain/enum/function-role.enum';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
+import { LoadingState } from '../../domain/enum/loading-state.enum';
+import { Observable } from 'rxjs';
 import { filter } from 'rxjs';
 
 @Component({
@@ -25,6 +27,7 @@ import { filter } from 'rxjs';
 export class DmpTableComponent implements OnChanges, AfterViewInit {
   @Input() dmps: DmpListItem[];
   @Input() admin = false;
+  @Input() dmpsLoaded: Observable<LoadingState>;
   dataSource = new MatTableDataSource();
 
   @Output() createDocument = new EventEmitter<number>();
@@ -34,10 +37,11 @@ export class DmpTableComponent implements OnChanges, AfterViewInit {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
 
+  searchTerm: string = '';
+
   readonly tableHeaders: string[] = [
     'title',
     'version',
-    'version_name',
     'created',
     'modified',
     'contact',
@@ -79,8 +83,8 @@ export class DmpTableComponent implements OnChanges, AfterViewInit {
     };
   }
 
-  applyFilter(event: Event) {
-    const filterValue = (event.target as HTMLInputElement).value;
+  applyFilter(filterValue: string) {
+    this.searchTerm = filterValue;
     this.dataSource.filter = filterValue.trim().toLowerCase();
 
     if (this.dataSource.paginator) {
@@ -99,4 +103,6 @@ export class DmpTableComponent implements OnChanges, AfterViewInit {
   deleteDmp(id: number) {
     this.dmpToDelete.emit(id);
   }
+
+  protected readonly LoadingState = LoadingState;
 }

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.module.ts
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.module.ts
@@ -14,12 +14,13 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-
+import { SharedModule } from '../../shared/shared.module';
 @NgModule({
   imports: [
     CommonModule,
     RouterModule,
     TranslateModule,
+    SharedModule,
 
     // Materials
     MatFormFieldModule,
@@ -39,6 +40,7 @@ import { TranslateModule } from '@ngx-translate/core';
     CommonModule,
     RouterModule,
     DmpTableComponent,
+    SharedModule,
 
     // Materials
     MatFormFieldModule,

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.html
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.html
@@ -1,27 +1,19 @@
 <form>
   <div class="form-row">
-    <mat-form-field class="full-width">
-      <mat-label>{{
-        "dmp.steps.data.specify.doi.search" | translate
-      }}</mat-label>
-      <input
-        matInput
-        #searchBox
-        type="search"
-        [formControl]="doi"
-        placeholder="10.5281/zenodo.3885730" />
-      <mat-icon matSuffix>search</mat-icon>
-      <mat-error *ngIf="doi?.errors?.doi">
-        {{ "form.error.doi" | translate }}
-      </mat-error>
-    </mat-form-field>
+    <app-search-field
+      class="full-width"
+      [label]="'dmp.steps.data.specify.doi.search'"
+      [placeholder]="'10.5281/zenodo.3885730'"
+      [control]="doi"
+      [errorMessage]="'form.error.doi'"
+      (searchChange)="searchChange($event)"></app-search-field>
     <button
       mat-raised-button
       class="button-color-primary"
       type="submit"
-      (click)="search(searchBox.value)"
+      (click)="search(searchTerm)"
       [disabled]="
-        !searchBox.value || doi.invalid || loading === loadingState.LOADING
+        !searchTerm || doi.invalid || loading === loadingState.LOADING
       ">
       {{ "dmp.steps.data.specify.button.add.doi" | translate }}
     </button>

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
@@ -29,6 +29,7 @@ export class DoiSearchComponent implements OnChanges {
   });
 
   readonly loadingState: any = LoadingState;
+  searchTerm: string = '';
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.loading) {
@@ -48,5 +49,9 @@ export class DoiSearchComponent implements OnChanges {
       term = term.substring(term.indexOf('10.')).trim();
       this.termToSearch.emit(term);
     }
+  }
+
+  searchChange(searchInput: string) {
+    this.searchTerm = searchInput;
   }
 }

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.module.ts
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.module.ts
@@ -9,6 +9,7 @@ import { MatOptionModule } from '@angular/material/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { ErrorMessageModule } from '../error-message/error-message.module';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   declarations: [DoiSearchComponent],
@@ -18,6 +19,7 @@ import { ErrorMessageModule } from '../error-message/error-message.module';
     FormsModule,
     ReactiveFormsModule,
     ErrorMessageModule,
+    SharedModule,
 
     // Materials
     MatFormFieldModule,
@@ -33,6 +35,7 @@ import { ErrorMessageModule } from '../error-message/error-message.module';
     ReactiveFormsModule,
     DoiSearchComponent,
     ErrorMessageModule,
+    SharedModule,
 
     // Materials
     MatFormFieldModule,

--- a/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.html
+++ b/libs/damap/src/lib/widgets/export-warning-dialog/export-warning-dialog.html
@@ -3,7 +3,7 @@
   {{'dialog.export.content' | translate}}
   <div class="container">
     <ng-container>
-      <mat-form-field appearance="fill" *ngIf="!funderSupported">
+      <mat-form-field *ngIf="!funderSupported">
         <mat-label>{{ 'dialog.export.type' | translate }}</mat-label>
         <mat-select [(value)]="selectedTemplate">
           <mat-option

--- a/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.html
+++ b/libs/damap/src/lib/widgets/internal-storage-table/internal-storage-table.component.html
@@ -1,4 +1,8 @@
-<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+<table
+  mat-table
+  [dataSource]="dataSource"
+  matSort
+  class="mat-elevation-z8 zebra-table">
   <!-- URL Column -->
   <ng-container matColumnDef="url">
     <th mat-header-cell *matHeaderCellDef mat-sort-header>

--- a/libs/damap/src/lib/widgets/license-wizard/license-wizard-dialog.html
+++ b/libs/damap/src/lib/widgets/license-wizard/license-wizard-dialog.html
@@ -53,17 +53,15 @@
   <ng-container
     *ngIf="(licenseList | licenseFilter: '')?.length else noLicense">
     <div id="ls-search">
-      <mat-form-field>
-        <mat-label>{{'license.wizard.search' | translate}}</mat-label>
-        <input #searchBox type="search" matInput />
-        <mat-icon matSuffix>search</mat-icon>
-      </mat-form-field>
+      <app-search-field
+        [label]="'license.wizard.search'"
+        (searchChange)="searchChange($event)"></app-search-field>
     </div>
     <div class="ls-list">
       <mat-card
         appearance="raised"
         class="ls-item"
-        *ngFor="let license of (licenseList | licenseFilter:searchBox.value)">
+        *ngFor="let license of (licenseList | licenseFilter:searchTerm)">
         <mat-card-content>
           <div class="ls-item-header">
             <h4 [mat-dialog-close]="license">{{license.name | translate}}</h4>

--- a/libs/damap/src/lib/widgets/license-wizard/license-wizard.component.ts
+++ b/libs/damap/src/lib/widgets/license-wizard/license-wizard.component.ts
@@ -45,8 +45,13 @@ export class LicenseSelectorDialogComponent {
   matrix: string[] = []; // compatible software license codes
   options: LicenseDetails[][] = []; // compatible data licenses
   steps: Step[] = [QUESTION_TREE];
+  searchTerm: string = '';
 
   constructor(public dialogRef: MatDialogRef<LicenseSelectorDialogComponent>) {}
+
+  searchChange(searchInput: string) {
+    this.searchTerm = searchInput;
+  }
 
   setNextStep(
     currentIndex: number,

--- a/libs/damap/src/lib/widgets/license-wizard/license-wizard.module.ts
+++ b/libs/damap/src/lib/widgets/license-wizard/license-wizard.module.ts
@@ -15,11 +15,13 @@ import { MatInputModule } from '@angular/material/input';
 import { NgModule } from '@angular/core';
 import { TooltipModule } from '../tooltip/tooltip.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   imports: [
     CommonModule,
     TranslateModule,
+    SharedModule,
 
     // Materials
     MatIconModule,
@@ -40,6 +42,7 @@ import { TranslateModule } from '@ngx-translate/core';
     CommonModule,
     TranslateModule,
     LicenseWizardComponent,
+    SharedModule,
 
     // Materials
     MatIconModule,

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.css
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.css
@@ -15,7 +15,7 @@
   overflow-y: auto;
 }
 
-.mat-card-container {
+.list-option-container {
   display: inline-block;
   margin: 10px;
 }

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.html
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.html
@@ -1,13 +1,8 @@
 <form>
-  <mat-form-field class="search-field">
-    <mat-label>{{ "dmp.steps.people.search" | translate }}</mat-label>
-    <input
-      #searchBox
-      type="search"
-      matInput
-      (input)="search(searchBox.value)" />
-    <mat-icon matSuffix>search</mat-icon>
-  </mat-form-field>
+  <app-search-field
+    class="search-field"
+    [label]="'dmp.steps.people.search'"
+    (searchChange)="search($event)"></app-search-field>
   <div class="result-list" *ngIf="currentSearchTerm && result.length > 0">
     <mat-selection-list
       hideSingleSelectionIndicator
@@ -18,29 +13,27 @@
         [style]="'height: auto;'"
         [selected]="false"
         [value]="person">
-        <mat-card-content>
-          <div class="mat-card-container">
-            <div>
-              <div matListItemTitle class="person-detail-content">
-                <strong> {{ person.firstName }} {{ person.lastName }} </strong>
-              </div>
-              <div
-                matListItemLine
-                *ngIf="person.mbox"
-                class="person-detail-content">
-                <mat-icon class="outline" inline="true">mail</mat-icon>
-                {{ person.mbox }}
-              </div>
-              <div
-                matListItemLine
-                *ngIf="person.personId?.identifier"
-                class="person-detail-content">
-                <mat-icon inline="true">fingerprint</mat-icon>
-                {{ person.personId?.type }}: {{ person.personId.identifier }}
-              </div>
+        <div class="list-option-container">
+          <div>
+            <div matListItemTitle class="person-detail-content">
+              <strong> {{ person.firstName }} {{ person.lastName }} </strong>
+            </div>
+            <div
+              matListItemLine
+              *ngIf="person.mbox"
+              class="person-detail-content">
+              <mat-icon class="outline" inline="true">mail</mat-icon>
+              {{ person.mbox }}
+            </div>
+            <div
+              matListItemLine
+              *ngIf="person.personId?.identifier"
+              class="person-detail-content">
+              <mat-icon inline="true">fingerprint</mat-icon>
+              {{ person.personId?.type }}: {{ person.personId.identifier }}
             </div>
           </div>
-        </mat-card-content>
+        </div>
       </mat-list-option>
     </mat-selection-list>
   </div>

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.spec.ts
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.spec.ts
@@ -15,6 +15,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PersonSearchComponent } from './person-search.component';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TranslateTestingModule } from '../../testing/translate-testing/translate-testing.module';
+import { SearchFieldComponent } from '../../shared/search-field/search-field.component';
 
 describe('PersonSearchComponent', () => {
   let component: PersonSearchComponent;
@@ -30,7 +31,7 @@ describe('PersonSearchComponent', () => {
         MatListModule,
         NoopAnimationsModule,
       ],
-      declarations: [PersonSearchComponent],
+      declarations: [PersonSearchComponent, SearchFieldComponent],
     }).compileComponents();
   }));
   beforeEach(() => {

--- a/libs/damap/src/lib/widgets/person-search/person-search.module.ts
+++ b/libs/damap/src/lib/widgets/person-search/person-search.module.ts
@@ -9,6 +9,7 @@ import { MatOptionModule } from '@angular/material/core';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { FormsModule } from '@angular/forms';
 import { MatListModule } from '@angular/material/list';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   declarations: [PersonSearchComponent],
@@ -16,6 +17,7 @@ import { MatListModule } from '@angular/material/list';
     CommonModule,
     TranslateModule,
     FormsModule,
+    SharedModule,
 
     // Materials
     MatFormFieldModule,
@@ -30,6 +32,7 @@ import { MatListModule } from '@angular/material/list';
     TranslateModule,
     FormsModule,
     PersonSearchComponent,
+    SharedModule,
 
     // Materials
     MatFormFieldModule,

--- a/libs/damap/src/lib/widgets/tree-select-form-field/tree-select-form-field.component.html
+++ b/libs/damap/src/lib/widgets/tree-select-form-field/tree-select-form-field.component.html
@@ -1,5 +1,5 @@
 <div class="tree-select">
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>{{ label }}</mat-label>
     <mat-chip-grid
       #chipList


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Refactoring

#### What does this PR do?

I created a global table css-class, that gives all tables in the project the zebra like appaerance. The dmp-table shown below got some additional styling. The light blue is the new color that appears when hovering over a table cell, this color changes with the color palette. I restyled the search fields and created a reusable component for them. Most notably they now use the outline appearance and are slimmer.
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/29e24ede-829a-4607-ad77-c41592c4350e">

They same is true for all the other form fields, i also made outline the default appearance. The only exception is the textarea wrapper, which i left filled and only with slightly reduced density. All outlined form-fields now have a primary colored border by default.

Before
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/3030f836-e141-4aaa-9e45-20126b2b9332">

 After
<img width="964" alt="image" src="https://github.com/user-attachments/assets/e52e274b-a799-44a6-aff7-d4d3ad5d3550">

There are also numerous small code improvements throughout the whole PR.

#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-319
