### PR TITLE
Version: Add new columns to DMP Table to display version count and last version name

### DIFF
--- a/libs/damap/src/assets/i18n/plans/de.json
+++ b/libs/damap/src/assets/i18n/plans/de.json
@@ -10,6 +10,8 @@
     "table": {
       "header": {
         "title": "Titel",
+        "version": "Version #",
+        "version_name": "Versionsname",
         "created": "Erstellt",
         "modified": "Zuletzt geändert",
         "contact": "Kontakt"

--- a/libs/damap/src/assets/i18n/plans/en.json
+++ b/libs/damap/src/assets/i18n/plans/en.json
@@ -11,6 +11,8 @@
     "table": {
       "header": {
         "title": "Title",
+        "version": "Version #",
+        "version_name": "Version Name",
         "created": "Created",
         "modified": "Last modified",
         "contact": "Contact"

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
@@ -23,6 +23,7 @@ import {
 import { Location } from '@angular/common';
 import { LivePreviewComponent } from '../live-preview/live-preview.component';
 import { BackendService } from '../../../services/backend.service';
+import { FeedbackService } from '../../../services/feedback.service';
 
 @Component({
   selector: 'app-actions',
@@ -50,6 +51,7 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
     private store: Store<AppState>,
     private location: Location,
     private backendService: BackendService,
+    private feedbackService: FeedbackService,
   ) {
     this.dmpForm = this.formService.dmpForm;
   }
@@ -100,13 +102,15 @@ export class DmpActionsComponent implements OnInit, OnDestroy {
     });
 
     dialogRef.afterClosed().subscribe(versionName => {
-      if (versionName) {
+      if (versionName && versionName.length <= 255) {
         this.store.dispatch(
           saveDmpVersion({
             dmp: this.formService.exportFormToDmp(),
             versionName,
           }),
         );
+      } else {
+        this.feedbackService.error('Version name is too long');
       }
     });
   }

--- a/libs/damap/src/lib/domain/dmp-list-item.ts
+++ b/libs/damap/src/lib/domain/dmp-list-item.ts
@@ -11,4 +11,6 @@ export interface DmpListItem {
   readonly description: string;
   readonly project: Project;
   readonly accessType: FunctionRole;
+  readonly versionCount: number;
+  readonly latestVersionName: string;
 }

--- a/libs/damap/src/lib/mocks/dmp-list-mocks.ts
+++ b/libs/damap/src/lib/mocks/dmp-list-mocks.ts
@@ -13,5 +13,7 @@ export const mockDmpList: DmpListItem[] = [
     description: 'Mock Dmp List Item',
     project: mockProject,
     accessType: FunctionRole.OWNER,
+    versionCount: 1,
+    latestVersionName: 'Mock Version',
   },
 ];

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.css
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.css
@@ -27,6 +27,13 @@ td.mat-column-contact {
   overflow: hidden;
 }
 
+td.mat-column-version,
+td.mat-column-version_name {
+  width: 150px;
+  overflow: hidden;
+  text-align: center;
+}
+
 .mat-column-edit {
   width: 30px;
 }
@@ -59,6 +66,11 @@ a.title {
   color: var(--on-surface);
 }
 
+a.version {
+  text-align: center;
+  color: var(--on-surface);
+}
+
 button.mat-focus-indicator .mat-mdc-unelevated-button.mat-primary,
 .mat-mdc-raised-button.mat-primary,
 .mat-mdc-fab.mat-primary,
@@ -68,4 +80,8 @@ button.mat-focus-indicator .mat-mdc-unelevated-button.mat-primary,
   justify-content: space-between;
   align-items: center;
   gap: 10px;
+}
+
+.word-break {
+  word-break: break-all;
 }

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
@@ -28,6 +28,28 @@
     </td>
   </ng-container>
 
+  <ng-container matColumnDef="version">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "plans.table.header.version" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">
+      <a class="version" routerLink="/dmp/{{ element.id }}/version">
+        {{ element.versionCount !== null ? element.versionCount : 0 }}
+      </a>
+    </td>
+  </ng-container>
+
+  <ng-container matColumnDef="version_name">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>
+      {{ "plans.table.header.version_name" | translate }}
+    </th>
+    <td mat-cell *matCellDef="let element">
+      <a class="version word-break" routerLink="/dmp/{{ element.id }}/version">
+        {{ element.latestVersionName }}
+      </a>
+    </td>
+  </ng-container>
+
   <ng-container matColumnDef="created">
     <th mat-header-cell *matHeaderCellDef mat-sort-header>
       {{ "plans.table.header.created" | translate }}

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.ts
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.ts
@@ -4,6 +4,7 @@ import {
   EventEmitter,
   Input,
   OnChanges,
+  OnInit,
   Output,
   SimpleChanges,
   ViewChild,
@@ -14,6 +15,7 @@ import { FunctionRole } from '../../domain/enum/function-role.enum';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'app-dmp-table',
@@ -34,6 +36,8 @@ export class DmpTableComponent implements OnChanges, AfterViewInit {
 
   readonly tableHeaders: string[] = [
     'title',
+    'version',
+    'version_name',
     'created',
     'modified',
     'contact',
@@ -51,6 +55,8 @@ export class DmpTableComponent implements OnChanges, AfterViewInit {
     this.dataSource.filterPredicate = (data: DmpListItem, filter: string) =>
       data.project?.title?.toLowerCase().includes(filter) ||
       data.title?.toLowerCase().includes(filter) ||
+      data.latestVersionName?.toLowerCase().includes(filter) ||
+      data.versionCount?.toString().includes(filter) ||
       data.id.toString().includes(filter);
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
@@ -63,6 +69,10 @@ export class DmpTableComponent implements OnChanges, AfterViewInit {
           return item.project?.title || 'DMP ID: ' + item.id;
         case 'contact':
           return item.contact?.firstName + ' ' + item.contact?.lastName;
+        case 'version':
+          return item.versionCount;
+        case 'version_name':
+          return item.latestVersionName;
         default:
           return item[property];
       }


### PR DESCRIPTION
## Description

Feature

#### What does this PR do?

Added two new columns to the DMP Table (Version count and Version name) to raise awareness about the existing versioning feature.

#### Breaking changes

Fixed a major bug regarding the length of the Versioning name in the frontend (as well as the backend),


#### Dependencies

Related backend PR, see:

https://github.com/tuwien-csd/damap-backend/pull/277

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-346
