### PR TITLE
UI: Add undefined check for version info for older backend versions in the DMP Table

### DIFF
--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
@@ -39,21 +39,29 @@
       <td mat-cell *matCellDef="let element">
         <a class="version" routerLink="/dmp/{{ element.id }}/version">
           {{
-            element.versionCount !== null
+            element.versionCount !== null && element.versionCount !== undefined
               ? ("plans.table.header.version_tag" | translate) + ": "
               : ""
           }}
           <span class="underlined">{{
-            element.versionCount !== null ? "#" + element.versionCount : ""
-          }}</span>
-          <br />
-          {{
-            element.versionCount !== null
-              ? ("plans.table.header.version_name" | translate) + ": "
+            element.versionCount !== null && element.versionCount !== undefined
+              ? "#" + element.versionCount
               : ""
+          }}</span>
+          <br
+            *ngIf="
+              element.versionCount !== null &&
+              element.versionCount !== undefined
+            " />
+          {{
+            element.versionCount !== null && element.versionCount !== undefined
+              ? ("plans.table.header.version_name" | translate) + ": "
+              : "No versions for this DMP available"
           }}
           <span class="underlined">{{
-            element.versionCount !== null ? element.latestVersionName : ""
+            element.versionCount !== null && element.versionCount !== undefined
+              ? element.latestVersionName
+              : ""
           }}</span>
         </a>
       </td>


### PR DESCRIPTION
## Description

Add check for undefined in the DMP Table Version Column (relevant if older backend version is used). Add verbiage to redirect to version page if no version is provided by the backend.

closes GH-360
