### PR TITLE
Live Preview: Add possibility to disable the feature in the config from the backend

### DIFF
--- a/apps/damap-frontend/src/app/services/config.service.spec.ts
+++ b/apps/damap-frontend/src/app/services/config.service.spec.ts
@@ -59,6 +59,7 @@ describe('ConfigService', () => {
         authUser: '',
         personSearchServiceConfigs: [],
         fitsServiceAvailable: false,
+        livePreviewAvailable: true,
       };
 
       mockOAuthService.loadDiscoveryDocumentAndTryLogin.and.returnValue(
@@ -115,6 +116,7 @@ describe('ConfigService', () => {
         authUser: '',
         personSearchServiceConfigs: [],
         fitsServiceAvailable: false,
+        livePreviewAvailable: true,
       };
 
       service['config'] = mockConfig;

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.html
@@ -65,6 +65,7 @@
       {{ "button.version" | translate }}
     </button>
     <div
+      *ngIf="preview"
       matTooltip="{{ 'button.preview.tooltipDisabled' | translate }}"
       [matTooltipDisabled]="previewEnabled()">
       <button

--- a/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp-actions/dmp-actions.component.ts
@@ -33,6 +33,7 @@ import { selectDmpSaving } from '../../../store/selectors/dmp.selectors';
 export class DmpActionsComponent implements OnInit, OnDestroy {
   @Input() stepChanged$: Subject<any>;
   @Input() admin = false;
+  @Input() preview = false;
 
   dmpForm: FormGroup;
 

--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -223,4 +223,5 @@
 <app-actions
   class="dmp-actions"
   [stepChanged$]="stepChanged$"
-  [admin]="admin"></app-actions>
+  [admin]="admin"
+  [preview]="livePreviewEnabled"></app-actions>

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -55,6 +55,7 @@ export class DmpComponent implements OnInit, OnDestroy {
   @ViewChild('legalEthicalAspects')
   legalEthicalAspectsComponent: LegalEthicalAspectsComponent;
   @ViewChild('repo') repoComponent: RepoComponent;
+  livePreviewEnabled: boolean = true;
 
   selectedViewStorage: 'primaryView' | 'secondaryView' = 'primaryView';
 
@@ -117,7 +118,10 @@ export class DmpComponent implements OnInit, OnDestroy {
     setTimeout(() => {
       this.getInstruction(0);
       this.config$ = this.backendService.loadServiceConfig();
-      this.config$.subscribe(() => this.cdr.detectChanges());
+      this.config$.subscribe(config => {
+        this.livePreviewEnabled = config.livePreviewAvailable;
+        this.cdr.detectChanges();
+      });
       this.dmpForm.valueChanges.subscribe(() => this.cdr.detectChanges());
       this.dmpForm.valueChanges.subscribe(value => {
         this.logger.debug(value);

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -8,4 +8,5 @@ export interface Config {
   readonly env: string;
   readonly personSearchServiceConfigs: ServiceConfig[];
   readonly fitsServiceAvailable: boolean;
+  readonly livePreviewAvailable: boolean;
 }

--- a/libs/damap/src/lib/mocks/config-service-mocks.ts
+++ b/libs/damap/src/lib/mocks/config-service-mocks.ts
@@ -16,4 +16,5 @@ export const configMockData: Config = {
   env: '',
   personSearchServiceConfigs: serviceConfigMockData,
   fitsServiceAvailable: true,
+  livePreviewAvailable: true,
 };


### PR DESCRIPTION
## Description

Depending on the value of the new field in the Config DTO, either hide or show the live preview button in the frontend (in the action bar at the bottom of the DMP page).

