### PR TITLE
Storage: Add dialog for storage information and update test

### DIFF
--- a/libs/damap/src/lib/components/dmp/data-storage/data-storage.module.ts
+++ b/libs/damap/src/lib/components/dmp/data-storage/data-storage.module.ts
@@ -4,6 +4,7 @@ import { DataStorageInstructionComponent } from './data-storage-instruction/data
 import { ExternalStorageComponent } from './external-storage/external-storage.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -14,6 +15,7 @@ import { SharedModule } from '../../../shared/shared.module';
 import { StepIntroModule } from '../../../widgets/step-intro/step-intro.module';
 import { StorageComponent } from './storage/storage.component';
 import { StorageFilterPipe } from './storage/storage-filter.pipe';
+import { StorageInfoDialogComponent } from './storage-dialog/storage-info-dialog.component';
 import { ToggleButtonsModule } from '../../../widgets/toggle-buttons/toggle-buttons.module';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -33,6 +35,9 @@ import { TranslateModule } from '@ngx-translate/core';
     MatButtonModule,
     MatCardModule,
     MatIconModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
   ],
   declarations: [
     DataAccessComponent,
@@ -40,6 +45,7 @@ import { TranslateModule } from '@ngx-translate/core';
     StorageComponent,
     StorageFilterPipe,
     DataStorageInstructionComponent,
+    StorageInfoDialogComponent,
   ],
   exports: [
     CommonModule,
@@ -51,12 +57,14 @@ import { TranslateModule } from '@ngx-translate/core';
     ExternalStorageComponent,
     StorageComponent,
     DataStorageInstructionComponent,
+    StorageInfoDialogComponent,
 
     // Materials
     MatExpansionModule,
     MatFormFieldModule,
     MatSelectModule,
     MatButtonModule,
+    MatDialogModule,
     MatCardModule,
     MatIconModule,
   ],

--- a/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.css
+++ b/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.css
@@ -19,10 +19,11 @@
   display: flex;
   flex-grow: 1;
   justify-content: space-between;
-  align-items: center;
+  align-items: baseline;
+  gap: 10px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .storage-card-top {
     flex-direction: row;
     align-items: flex-start;
@@ -39,7 +40,7 @@
   width: 30%;
   margin-top: 15px;
   max-height: 400px;
-  overflow-y: scroll;
+  overflow-y: hidden;
   overflow-x: hidden;
   margin-bottom: 20px;
 }
@@ -79,6 +80,11 @@
     width: 100%;
     margin-top: 10px;
     max-height: 200px;
+  }
+
+  .storage-textarea {
+    margin-top: 15px;
+    margin-left: 5px;
   }
 
   .storage-card-container,

--- a/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/external-storage/external-storage.component.html
@@ -27,15 +27,13 @@
               <app-input-wrapper
                 [label]="'dmp.steps.storage.external.question.name'"
                 [control]="getFormControl(i, 'title')"></app-input-wrapper>
-              <button
-                mat-icon-button
-                aria-label="{{
-                  'dmp.steps.storage.external.remove' | translate
-                }}"
-                (click)="removeExternalStorage(i)">
-                <mat-icon class="material-icon-primary">cancel</mat-icon>
-              </button>
             </div>
+            <button
+              mat-icon-button
+              aria-label="{{ 'dmp.steps.storage.external.remove' | translate }}"
+              (click)="removeExternalStorage(i)">
+              <mat-icon class="material-icon-primary">cancel</mat-icon>
+            </button>
           </div>
           <div class="form-row">
             <div class="storage-card-container">

--- a/libs/damap/src/lib/components/dmp/data-storage/storage-dialog/storage-info-dialog.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage-dialog/storage-info-dialog.component.html
@@ -1,0 +1,12 @@
+<h2 mat-dialog-title>{{ data.title }}</h2>
+<mat-dialog-content>
+  <p>{{ data.description }}</p>
+  <p>
+    <a href="{{ data.link }}" target="_blank" rel="noopener">
+      {{ "dmp.steps.storage.link" | translate }}
+    </a>
+  </p>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">{{ "Cancel" | translate }}</button>
+</mat-dialog-actions>

--- a/libs/damap/src/lib/components/dmp/data-storage/storage-dialog/storage-info-dialog.component.ts
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage-dialog/storage-info-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-storage-info-dialog',
+  templateUrl: './storage-info-dialog.component.html',
+})
+export class StorageInfoDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<StorageInfoDialogComponent>,
+    @Inject(MAT_DIALOG_DATA)
+    public data: {
+      title: string;
+      description: string;
+      link: string;
+      name: string;
+    },
+  ) {}
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+}

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.css
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.css
@@ -28,7 +28,7 @@
 
 .storage-avatar {
   background-color: var(--primary-color-light);
-  color: white;
+  color: var(--primary-lightest);
   width: 30px;
   height: 30px;
 }

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.html
@@ -12,7 +12,7 @@
       class="storage-card card-shadow">
       <mat-card-header
         (click)="addStorage(element)"
-        onKeyDown="addStorage(element)">
+        (keydown.enter)="addStorage(element)">
         <div mat-card-avatar>
           <mat-icon>folder_open</mat-icon>
         </div>
@@ -20,13 +20,9 @@
       </mat-card-header>
       <ng-container *ngIf="element.url">
         <mat-card-content>
-          <a
-            class="mat-title-small"
-            href="{{ element.url }}"
-            target="_blank"
-            rel="noopener"
-            >{{ "dmp.steps.storage.link" | translate }}</a
-          >
+          <button mat-button (click)="openStorageInfo(element)">
+            {{ "dmp.steps.storage.link" | translate }}
+          </button>
         </mat-card-content>
       </ng-container>
     </mat-card>

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.spec.ts
@@ -5,9 +5,11 @@ import {
 } from '../../../../store/selectors/internal-storage.selectors';
 
 import { LoadingState } from '../../../../domain/enum/loading-state.enum';
+import { MatDialog } from '@angular/material/dialog';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { StorageComponent } from './storage.component';
 import { StorageFilterPipe } from './storage-filter.pipe';
+import { StorageInfoDialogComponent } from '../storage-dialog/storage-info-dialog.component';
 import { TranslateTestingModule } from '../../../../testing/translate-testing/translate-testing.module';
 import { mockInternalStorage } from '../../../../mocks/storage-mocks';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -15,8 +17,11 @@ import { provideMockStore } from '@ngrx/store/testing';
 describe('StorageComponent', () => {
   let component: StorageComponent;
   let fixture: ComponentFixture<StorageComponent>;
+  let mockDialog: jasmine.SpyObj<MatDialog>;
 
   beforeEach(waitForAsync(() => {
+    mockDialog = jasmine.createSpyObj('MatDialog', ['open']);
+
     TestBed.configureTestingModule({
       imports: [TranslateTestingModule],
       schemas: [NO_ERRORS_SCHEMA],
@@ -31,6 +36,7 @@ describe('StorageComponent', () => {
             { selector: selectInternalStorages, value: [mockInternalStorage] },
           ],
         }),
+        { provide: MatDialog, useValue: mockDialog },
       ],
     }).compileComponents();
   }));
@@ -43,5 +49,19 @@ describe('StorageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should open the dialog with storage info', () => {
+    const expectedData = {
+      title: 'Test Title',
+      description: 'Test Description',
+      link: 'https://example.com',
+    };
+    component.openStorageInfo(mockInternalStorage);
+
+    expect(mockDialog.open).toHaveBeenCalledWith(StorageInfoDialogComponent, {
+      width: '500px',
+      data: expectedData,
+    });
   });
 });

--- a/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
+++ b/libs/damap/src/lib/components/dmp/data-storage/storage/storage.component.ts
@@ -9,6 +9,8 @@ import {
 import { AppState } from '../../../../store/states/app.state';
 import { InternalStorage } from '../../../../domain/internal-storage';
 import { LoadingState } from '../../../../domain/enum/loading-state.enum';
+import { MatDialog } from '@angular/material/dialog';
+import { StorageInfoDialogComponent } from '../storage-dialog/storage-info-dialog.component';
 import { loadInternalStorages } from '../../../../store/actions/internal-storage.actions';
 
 @Component({
@@ -28,7 +30,10 @@ export class StorageComponent implements OnInit {
   internalStoragesLoaded: LoadingState;
   showAdditionalStorage: boolean = false;
 
-  constructor(private store: Store<AppState>) {}
+  constructor(
+    private store: Store<AppState>,
+    private dialog: MatDialog,
+  ) {}
 
   ngOnInit() {
     this.store
@@ -63,5 +68,19 @@ export class StorageComponent implements OnInit {
       t => t.languageCode === 'eng',
     );
     return translation ? translation.title : storage.translations[0].title;
+  }
+
+  openStorageInfo(storage: InternalStorage) {
+    const translation =
+      storage.translations.find(t => t.languageCode === 'eng') ||
+      storage.translations[0];
+    this.dialog.open(StorageInfoDialogComponent, {
+      width: '500px',
+      data: {
+        title: translation.title,
+        description: translation.description,
+        link: storage.url,
+      },
+    });
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
![Screenshot 2024-12-03 at 11 19 11](https://github.com/user-attachments/assets/31b7318a-d646-4327-baf0-1ab8b300ad29)

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?

This PR introduces a new dialog for displaying storage information, replacing the existing storage links. Key changes include:

- Added `StorageInfoDialogComponent` to display detailed storage descriptions and links in a popup.
- Integrated the new dialog functionality into `StorageComponent` via the `openStorageInfo` method.
- Updated the test suite 
- While solving the task, resolved a minor styling issue for small screens: adjusted the "Close" button in the "Add Other Storage Location" dialog for better alignment.

#### Breaking changes

#### Breaking changes
No breaking changes.

#### Code review focus

- Ensure the dialog functionality works as intended for various storage options.
- Verify the alignment of tests with the new `openStorageInfo` method and `InternalStorage` mock data.
- Confirm the minor styling fix for small screens does not introduce regressions.

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
