### PR TITLE
Ethical: Add new ethical report uri field to frontend  (disableable from the backend)

### DIFF
--- a/apps/damap-frontend/src/app/services/config.service.spec.ts
+++ b/apps/damap-frontend/src/app/services/config.service.spec.ts
@@ -60,6 +60,7 @@ describe('ConfigService', () => {
         personSearchServiceConfigs: [],
         fitsServiceAvailable: false,
         livePreviewAvailable: true,
+        ethicalReportEnabled: true,
       };
 
       mockOAuthService.loadDiscoveryDocumentAndTryLogin.and.returnValue(
@@ -117,6 +118,7 @@ describe('ConfigService', () => {
         personSearchServiceConfigs: [],
         fitsServiceAvailable: false,
         livePreviewAvailable: true,
+        ethicalReportEnabled: true,
       };
 
       service['config'] = mockConfig;

--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -273,7 +273,8 @@
               "link": "https://www.tuwien.at/forschung/fti-support/responsible-research-practices/research-ethics-committee"
             },
             "suffix": ", or a similar body?"
-          }
+          },
+          "ethicalIssueReport": "Please provide the ethical issue report."
         }
       },
       "licensing": {
@@ -491,6 +492,8 @@
       "maxlength": "Value must not exceed {{value}} characters.",
       "pattern.currency": "Invalid input, please use the following format: 1234.56",
       "orcid": "Invalid ORCID iD.",
+      "url": "Invalid URL. Must be formatted as https://example.com",
+      "uri": "Invalid URI",
       "doi": "Invalid DOI. Must be formatted as 10.1234/56789 or https://doi.org/10.1234/56789 or doi:10.1234/56789",
       "duplicateDoi": "DOI already added."
     },

--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -156,11 +156,9 @@
           #legalEthicalAspects
           [dmpForm]="dmpForm"
           [legalEthicalStep]="legalEthicalStep"
-          [datasets]="datasets">
+          [datasets]="datasets"
+          [ethicalReportEnabled]="ethicalReportEnabled">
         </app-dmp-legal-ethical-aspects>
-        <div *ngIf="legalEthicalStep.invalid" class="error-message">
-          {{ "dmp.steps.legal.error" | translate }}
-        </div>
       </ng-container>
     </ng-container>
     <ng-container *ngIf="selectedStep === 6">

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -56,6 +56,7 @@ export class DmpComponent implements OnInit, OnDestroy {
   legalEthicalAspectsComponent: LegalEthicalAspectsComponent;
   @ViewChild('repo') repoComponent: RepoComponent;
   livePreviewEnabled: boolean = true;
+  ethicalReportEnabled: boolean = true;
 
   selectedViewStorage: 'primaryView' | 'secondaryView' = 'primaryView';
 
@@ -120,6 +121,7 @@ export class DmpComponent implements OnInit, OnDestroy {
       this.config$ = this.backendService.loadServiceConfig();
       this.config$.subscribe(config => {
         this.livePreviewEnabled = config.livePreviewAvailable;
+        this.ethicalReportEnabled = config.ethicalReportEnabled;
         this.cdr.detectChanges();
       });
       this.dmpForm.valueChanges.subscribe(() => this.cdr.detectChanges());

--- a/libs/damap/src/lib/components/dmp/legal-ethical-aspects/ethical-aspects/ethical-aspects.component.html
+++ b/libs/damap/src/lib/components/dmp/legal-ethical-aspects/ethical-aspects/ethical-aspects.component.html
@@ -109,6 +109,16 @@
           </mat-radio-button>
         </mat-radio-group>
       </div>
+      <div
+        *ngIf="
+          legalEthicalStep.controls.committeeReviewed.value &&
+          ethicalReportEnabled
+        ">
+        <app-input-wrapper
+          [label]="'dmp.steps.ethical.question.ethicalIssueReport'"
+          [maxLength]="255"
+          [control]="ethicalIssuesReport"></app-input-wrapper>
+      </div>
       <app-info-message>
         {{ "info.ethical.committeeReviewed.prefix" | translate }}
         <a

--- a/libs/damap/src/lib/components/dmp/legal-ethical-aspects/ethical-aspects/ethical-aspects.component.ts
+++ b/libs/damap/src/lib/components/dmp/legal-ethical-aspects/ethical-aspects/ethical-aspects.component.ts
@@ -1,11 +1,27 @@
-import { Component, Input } from '@angular/core';
-import { UntypedFormGroup } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-ethical-aspects',
   templateUrl: './ethical-aspects.component.html',
   styleUrls: ['./ethical-aspects.component.css'],
 })
-export class EthicalAspectsComponent {
+export class EthicalAspectsComponent implements OnInit {
   @Input() legalEthicalStep: UntypedFormGroup;
+  @Input() ethicalReportEnabled: boolean;
+
+  get ethicalIssuesReport(): UntypedFormControl {
+    return this.legalEthicalStep.get(
+      'ethicalIssuesReport',
+    ) as UntypedFormControl;
+  }
+
+  ngOnInit(): void {
+    this.legalEthicalStep
+      .get('committeeReviewed')
+      .valueChanges.subscribe(value => {
+        // Set ethical Report URL to ""
+        this.ethicalIssuesReport.setValue(null);
+      });
+  }
 }

--- a/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.component.html
+++ b/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.component.html
@@ -263,5 +263,6 @@
     >{{ "dmp.steps.ethical.heading" | translate }}</mat-label
   >
   <app-ethical-aspects
-    [legalEthicalStep]="legalEthicalStep"></app-ethical-aspects>
+    [legalEthicalStep]="legalEthicalStep"
+    [ethicalReportEnabled]="ethicalReportEnabled"></app-ethical-aspects>
 </div>

--- a/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.component.ts
+++ b/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.component.ts
@@ -18,6 +18,7 @@ export class LegalEthicalAspectsComponent {
   @Input() dmpForm: UntypedFormGroup;
   @Input() legalEthicalStep: UntypedFormGroup;
   @Input() datasets: UntypedFormArray;
+  @Input() ethicalReportEnabled: boolean;
 
   translateAgreementPrefixEnum = 'enum.agreement.';
   translateCompliancePrefixEnum = 'enum.compliance.';

--- a/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.module.ts
+++ b/libs/damap/src/lib/components/dmp/legal-ethical-aspects/legal-ethical-aspects.module.ts
@@ -13,6 +13,7 @@ import { StepIntroModule } from '../../../widgets/step-intro/step-intro.module';
 import { ToggleButtonsModule } from '../../../widgets/toggle-buttons/toggle-buttons.module';
 import { TooltipModule } from '../../../widgets/tooltip/tooltip.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { TextFieldModule } from '@angular/cdk/text-field';
 
 @NgModule({
   imports: [

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -9,4 +9,5 @@ export interface Config {
   readonly personSearchServiceConfigs: ServiceConfig[];
   readonly fitsServiceAvailable: boolean;
   readonly livePreviewAvailable: boolean;
+  readonly ethicalReportEnabled: boolean;
 }

--- a/libs/damap/src/lib/domain/dmp.ts
+++ b/libs/damap/src/lib/domain/dmp.ts
@@ -50,6 +50,7 @@ export interface Dmp {
   ethicalIssuesExistCris: boolean;
   committeeReviewed: boolean;
   committeeReviewedCris: boolean;
+  ethicalIssuesReport: string;
   storage: Storage[];
   externalStorage: ExternalStorage[];
   externalStorageInfo: string;

--- a/libs/damap/src/lib/mocks/config-service-mocks.ts
+++ b/libs/damap/src/lib/mocks/config-service-mocks.ts
@@ -17,4 +17,5 @@ export const configMockData: Config = {
   personSearchServiceConfigs: serviceConfigMockData,
   fitsServiceAvailable: true,
   livePreviewAvailable: true,
+  ethicalReportEnabled: true,
 };

--- a/libs/damap/src/lib/mocks/dmp-mocks.ts
+++ b/libs/damap/src/lib/mocks/dmp-mocks.ts
@@ -102,6 +102,7 @@ export const completeDmp: Dmp = {
   structure: 'VCS',
   targetAudience: 'students',
   tools: 'proprietary software needed',
+  ethicalIssuesReport: '',
 };
 
 export const noDataDmp: Dmp = {
@@ -171,4 +172,5 @@ export const noDataDmp: Dmp = {
   structure: 'VCS',
   targetAudience: 'students',
   tools: 'proprietary software needed',
+  ethicalIssuesReport: '',
 };

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -22,6 +22,8 @@ import { Storage } from '../domain/storage';
 import { ccBy } from '../widgets/license-wizard/license-wizard-list';
 import { currencyValidator } from '../validators/currency.validator';
 import { notEmptyValidator } from '../validators/not-empty.validator';
+import { urlValidator } from '../validators/url.validator';
+import { uriValidator } from '../validators/uri.validator';
 
 @Injectable({
   providedIn: 'root',
@@ -114,6 +116,7 @@ export class FormService {
         ethicalIssuesCris: [null],
         committeeReviewed: [false],
         committeeReviewedCris: [null],
+        ethicalIssuesReport: ['', Validators.maxLength(this.TEXT_SHORT_LENGTH)],
       }),
       repositories: this.formBuilder.array([]),
       reuse: this.formBuilder.group({
@@ -173,6 +176,7 @@ export class FormService {
         ethicalIssuesCris: dmp.ethicalIssuesExistCris,
         committeeReviewed: dmp.committeeReviewed,
         committeeReviewedCris: dmp.committeeReviewedCris,
+        ethicalIssuesReport: dmp.ethicalIssuesReport,
       },
       reuse: {
         targetAudience: dmp.targetAudience,
@@ -274,6 +278,7 @@ export class FormService {
       tools: formValue.reuse.tools,
       id: formValue.id,
       project: formValue.project,
+      ethicalIssuesReport: formValue.legal.ethicalIssuesReport,
     };
   }
 

--- a/libs/damap/src/lib/services/summary.service.spec.ts
+++ b/libs/damap/src/lib/services/summary.service.spec.ts
@@ -403,5 +403,6 @@ describe('SummaryService', () => {
     structure: '',
     targetAudience: '',
     tools: '',
+    ethicalIssuesReport: '',
   };
 });

--- a/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.html
+++ b/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.html
@@ -34,6 +34,12 @@
   <mat-error *ngIf="control?.errors?.orcid">
     {{ "form.error.orcid" | translate }}
   </mat-error>
+  <mat-error *ngIf="control?.errors?.url">
+    {{ "form.error.url" | translate }}
+  </mat-error>
+  <mat-error *ngIf="control?.errors?.uri">
+    {{ "form.error.uri" | translate }}
+  </mat-error>
 </mat-form-field>
 <!--{{control.errors | json}}-->
 <!--{{control.valid}}-->

--- a/libs/damap/src/lib/store/states/form.state.ts
+++ b/libs/damap/src/lib/store/states/form.state.ts
@@ -53,6 +53,7 @@ export const initialFormState: FormState = {
     tools: '',
     id: null,
     project: null,
+    ethicalIssuesReport: '',
   },
   changed: undefined,
 };

--- a/libs/damap/src/lib/validators/uri.validator.ts
+++ b/libs/damap/src/lib/validators/uri.validator.ts
@@ -1,0 +1,25 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { Observable, of } from 'rxjs';
+
+/**
+ * Validates whether a given string is a valid URI based on RFC 3986.
+ * @param uri The string to validate.
+ * @returns True if the string is a valid URI, false otherwise.
+ */
+function isValidURI(uri: string): boolean {
+  // Regular expression to match a general URI pattern based on RFC 3986.
+  const uriRegex = /^[a-zA-Z][a-zA-Z0-9+.-]*:[^\s]*$/;
+  return uriRegex.test(uri);
+}
+
+/**
+ * A custom validator for validating URIs.
+ * @returns Validator function for Angular forms.
+ */
+export function uriValidator(): ValidatorFn {
+  return (control: AbstractControl): Observable<ValidationErrors | null> => {
+    const uri = control.value;
+    const isValid = !uri || isValidURI(uri);
+    return of(isValid ? null : { uri: true });
+  };
+}

--- a/libs/damap/src/lib/validators/url.validator.ts
+++ b/libs/damap/src/lib/validators/url.validator.ts
@@ -1,0 +1,20 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import validator from 'validator';
+import { Observable, of } from 'rxjs';
+
+export function urlValidator(): ValidatorFn {
+  return (control: AbstractControl): Observable<ValidationErrors | null> => {
+    const url = control.value;
+    const isValid =
+      !url ||
+      validator.isURL(url, {
+        protocols: ['http', 'https'],
+        require_protocol: false,
+        require_valid_protocol: true,
+        allow_underscores: false,
+        allow_trailing_dot: false,
+        allow_protocol_relative_urls: false,
+      });
+    return of(isValid ? null : { url: true });
+  };
+}


### PR DESCRIPTION
## Description

Feature

#### What does this PR do?

Add new ethical report URI field in the frontend step 6 ("Ethical aspects" view), the input field is only being displayed if it is not disabled through the config and if the Question "Was your research plan reviewed by an ethics committee, the Ethics Committee of your institution , or a similar body?" has been answered with yes.

A new URI and URL Validator have been introduced in a reusable manner.

#### Dependencies

[Related Backend PR](https://github.com/tuwien-csd/damap-backend/pull/302)

closes GH-382
