### PR TITLE
Global: make project title configurable via environment variable

### DIFF
--- a/apps/damap-frontend/src/app/app.component.spec.ts
+++ b/apps/damap-frontend/src/app/app.component.spec.ts
@@ -2,16 +2,25 @@ import { TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AppComponent } from './app.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ConfigService } from './services/config.service';
 import { Title } from '@angular/platform-browser';
-import { environment } from '../environments/environment';
 
 describe('AppComponent', () => {
   let titleService: Title;
+  let mockConfigService: jasmine.SpyObj<ConfigService>;
+
   beforeEach(waitForAsync(() => {
+    mockConfigService = jasmine.createSpyObj('ConfigService', ['getAppTitle']);
+
     TestBed.configureTestingModule({
       declarations: [AppComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        Title,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
     }).compileComponents();
+
     titleService = TestBed.inject(Title);
   }));
 
@@ -21,11 +30,22 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should set the title to 'Damap Frontend'`, () => {
+  it(`should set the title to the value provided by ConfigService`, () => {
+    const appTitle = 'Custom App Title';
+    mockConfigService.getAppTitle.and.returnValue(appTitle);
+
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    expect(titleService.getTitle()).toEqual(
-      environment.title || 'Damap Frontend',
-    );
+
+    expect(titleService.getTitle()).toEqual(appTitle);
+  });
+
+  it(`should set the title to 'Damap Frontend' if ConfigService returns null or undefined`, () => {
+    mockConfigService.getAppTitle.and.returnValue('');
+
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    expect(titleService.getTitle()).toEqual('Damap Frontend');
   });
 });

--- a/apps/damap-frontend/src/app/app.component.ts
+++ b/apps/damap-frontend/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+
+import { ConfigService } from './services/config.service';
 import { Title } from '@angular/platform-browser';
-import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -8,11 +9,16 @@ import { environment } from '../environments/environment';
   styleUrls: [],
 })
 export class AppComponent implements OnInit {
-  constructor(private titleService: Title) {}
+  constructor(
+    private titleService: Title,
+    private configService: ConfigService,
+  ) {}
 
   ngOnInit(): void {
-    if (environment.title) {
-      this.titleService.setTitle(environment.title);
+    const appTitle = this.configService.getAppTitle();
+
+    if (appTitle) {
+      this.titleService.setTitle(appTitle);
     } else {
       this.titleService.setTitle('Damap Frontend');
     }

--- a/apps/damap-frontend/src/app/services/config.service.spec.ts
+++ b/apps/damap-frontend/src/app/services/config.service.spec.ts
@@ -1,14 +1,14 @@
-import { TestBed } from '@angular/core/testing';
-
-import { ConfigService } from './config.service';
 import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
-import { OAuthService } from 'angular-oauth2-oidc';
-import { isDevMode, NO_ERRORS_SCHEMA } from '@angular/core';
-import { Router } from '@angular/router';
+import { NO_ERRORS_SCHEMA, isDevMode } from '@angular/core';
+
 import { Config } from '@damap/core';
+import { ConfigService } from './config.service';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { Router } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
 import { environment } from '../../environments/environment';
 
 describe('ConfigService', () => {
@@ -18,6 +18,8 @@ describe('ConfigService', () => {
   let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
+    spyOn(console, 'warn'); // Set up the spy only once.
+
     const oauthSpy = jasmine.createSpyObj('OAuthService', [
       'configure',
       'setupAutomaticSilentRefresh',
@@ -37,12 +39,12 @@ describe('ConfigService', () => {
         { provide: Router, useValue: routerSpy },
       ],
     });
+
     service = TestBed.inject(ConfigService);
     httpMock = TestBed.inject(HttpTestingController);
     mockOAuthService = TestBed.inject(
       OAuthService,
     ) as jasmine.SpyObj<OAuthService>;
-    // mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
   });
 
   afterEach(() => {
@@ -56,6 +58,7 @@ describe('ConfigService', () => {
         authClient: 'client-id',
         authScope: 'scope',
         env: 'test-env',
+        appTitle: 'Test App Title',
         authUser: '',
         personSearchServiceConfigs: [],
         fitsServiceAvailable: false,
@@ -76,7 +79,6 @@ describe('ConfigService', () => {
 
       await initializePromise;
 
-      // Verify OAuth configuration was called
       expect(mockOAuthService.configure).toHaveBeenCalledWith({
         issuer: mockConfig.authUrl,
         clientId: mockConfig.authClient,
@@ -91,28 +93,45 @@ describe('ConfigService', () => {
       expect(mockOAuthService.setupAutomaticSilentRefresh).toHaveBeenCalled();
     });
 
-    it('should handle config loading failure', async () => {
-      const consoleErrorSpy = spyOn(console, 'error');
+    it('should log a warning if appTitle is missing', async () => {
+      const mockConfig = {
+        authUrl: 'https://auth-url',
+        authClient: 'client-id',
+        authScope: 'scope',
+        env: 'test-env',
+        appTitle: null,
+        authUser: '',
+        personSearchServiceConfigs: [],
+        fitsServiceAvailable: false,
+        livePreviewAvailable: true,
+      };
+
+      mockOAuthService.loadDiscoveryDocumentAndTryLogin.and.returnValue(
+        Promise.resolve(true),
+      );
+      mockOAuthService.hasValidIdToken.and.returnValue(true);
+      mockOAuthService.hasValidAccessToken.and.returnValue(true);
 
       const initializePromise = service.initializeApp();
       const req = httpMock.expectOne(`${environment.backendurl}config`);
-      req.error(new ErrorEvent('Network error'));
+      req.flush(mockConfig);
 
       await initializePromise;
-
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to load config - please make sure your backend is up and running!',
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith(
+        'App title is missing in the config',
       );
     });
   });
 
-  describe('#getEnvironment', () => {
-    it('should return the environment from the loaded config', async () => {
+  describe('#getAppTitle', () => {
+    it('should return the appTitle from the loaded config', () => {
       const mockConfig: Config = {
         authUrl: 'https://auth-url',
         authClient: 'client-id',
         authScope: 'scope',
         env: 'test-env',
+        appTitle: 'Test App Title',
         authUser: '',
         personSearchServiceConfigs: [],
         fitsServiceAvailable: false,
@@ -121,22 +140,27 @@ describe('ConfigService', () => {
 
       service['config'] = mockConfig;
 
-      const environment = service.getEnvironment();
-      expect(environment).toEqual('test-env');
+      const appTitle = service.getAppTitle();
+      expect(appTitle).toEqual('Test App Title');
+    });
+
+    it('should return the default title if appTitle is missing', () => {
+      service['config'] = null;
+
+      const appTitle = service.getAppTitle();
+      expect(appTitle).toEqual('DAMAP Frontend');
     });
   });
 
   describe('initializeApp with no config', () => {
     it('should return false and log error when config is missing', async () => {
-      spyOn(console, 'error'); // Spy on console.error to check if it was called
-
-      service.initializeApp().then(result => {
-        expect(result).toBeFalse();
-      });
-
+      const initializePromise = service.initializeApp();
       const req = httpMock.expectOne(`${environment.backendurl}config`);
-      expect(req.request.method).toBe('GET');
-      req.flush(null); // Respond with null to simulate missing config
+      req.flush(null);
+
+      await initializePromise;
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith('Config is missing!');
     });
   });
 });

--- a/apps/damap-frontend/src/app/services/config.service.ts
+++ b/apps/damap-frontend/src/app/services/config.service.ts
@@ -25,10 +25,15 @@ export class ConfigService {
       .then((config: Config) => {
         if (!config) {
           // eslint-disable-next-line no-console
-          console.error('Config is missing!');
+          console.warn('Config is missing!');
           return new Promise<boolean>(resolve => resolve(false));
         } else {
           this.config = config;
+          const appTitle = config.appTitle;
+          if (!appTitle) {
+            // eslint-disable-next-line no-console
+            console.warn('App title is missing in the config');
+          }
           this.configSubject.next(config);
           const authConfig: AuthConfig = {
             issuer: config.authUrl,
@@ -65,6 +70,7 @@ export class ConfigService {
         console.error(
           'Failed to load config - please make sure your backend is up and running!',
         );
+
         console.log('Backend: ' + environment.backendurl);
         console.error(error);
         /* eslint-disable no-console */
@@ -74,6 +80,10 @@ export class ConfigService {
 
   public getEnvironment() {
     return this.config.env;
+  }
+
+  public getAppTitle(): string {
+    return this.config?.appTitle || 'DAMAP Frontend';
   }
 
   public getConfig$(): Observable<Config> {

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -6,6 +6,7 @@ export interface Config {
   readonly authScope: string;
   readonly authUser: string;
   readonly env: string;
+  readonly appTitle: string;
   readonly personSearchServiceConfigs: ServiceConfig[];
   readonly fitsServiceAvailable: boolean;
   readonly livePreviewAvailable: boolean;

--- a/libs/damap/src/lib/mocks/config-service-mocks.ts
+++ b/libs/damap/src/lib/mocks/config-service-mocks.ts
@@ -14,6 +14,7 @@ export const configMockData: Config = {
   authScope: '',
   authUser: '',
   env: '',
+  appTitle: '',
   personSearchServiceConfigs: serviceConfigMockData,
   fitsServiceAvailable: true,
   livePreviewAvailable: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

#### What does this PR do?

This PR adds support for dynamically setting the project title in the frontend application based on the backend-provided configuration. Previously, the title was statically set in the frontend. With this change, the title is dynamically fetched and applied from the backend’s /api/config endpoint.

#### Breaking changes

This PR does not introduce breaking changes. If the appTitle field is not provided by the backend, the application will default to “DAMAP Tool” as the browser title.

#### Code review focus

- Ensure the appTitle is correctly fetched from the backend and set as the browser title.
- Verify the frontend handles missing appTitle gracefully.
- Check the default title is used when appTitle is not provided.

Backend: https://github.com/tuwien-csd/damap-backend/issues/319

#### Steps

Dynamic Title Handling:

- Updated ConfigService to fetch and expose appTitle from /api/config.
- Added a getAppTitle method in ConfigService for dynamic title retrieval.
- Modified AppComponent to use ConfigService for setting the browser title.

Error Handling:

- Added fallback logic to use a default title if appTitle is missing.
- Logged a console warning when appTitle is not provided.

Unit Test Updates:

- Updated mock configurations to include appTitle.
- Added test cases for ConfigService to handle appTitle presence and fallback.
- Verified AppComponent dynamically sets the correct browser title.

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
