### PR TITLE
InternalStorageTranslations: Reenable editing

### DIFF
--- a/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.html
+++ b/libs/damap/src/lib/widgets/internal-storage-translation-table/internal-storage-translation-table.component.html
@@ -40,18 +40,8 @@
       <button mat-icon-button [matMenuTriggerFor]="menu">
         <mat-icon>more_vert</mat-icon>
       </button>
-      <!--
-      TODO: Re-enable editStorageTranslation when the database issue is resolved.
-      After updating a translation, an old audited version of the translation is still referenced
-      on the datasets. This causes the translation to be displayed incorrectly on the datasets.
-      See: https://github.com/tuwien-csd/damap-backend/issues/280
-      -->
       <mat-menu #menu="matMenu">
-        <button
-          mat-menu-item
-          (click)="editStorageTranslation(element.id)"
-          [disabled]="true"
-          matTooltip="Due to an issue with the database after editing a translation, this feature is currently disabled.">
+        <button mat-menu-item (click)="editStorageTranslation(element.id)">
           <mat-icon>edit</mat-icon>
           {{ "admin.table.action.edit" | translate }}
         </button>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

Editing translations in the frontend was temporarily disabled. Since the bug we wanted to prevent from occuring is fixed, this PR reenables it.
