### PR TITLE
Add new icons to the stepper: Add an icon for each state of the steps

### DIFF
--- a/apps/damap-frontend/src/styles.scss
+++ b/apps/damap-frontend/src/styles.scss
@@ -86,6 +86,7 @@
   // mat3 provides colors for error states, but not for success or warning...
   // so it is set to predefined values here
   --success-container: #e9f5d2;
+  --success-icon-color: #{mat.get-theme-color($app-light-theme, tertiary, 70)};
   --on-success-container: black;
   --warning-bg: #fff4cb;
   --background-body: #f6f6f6;

--- a/apps/damap-frontend/src/themes/custom-theme.scss
+++ b/apps/damap-frontend/src/themes/custom-theme.scss
@@ -162,6 +162,12 @@ html {
   background-color: var(--primary);
 }
 
+.material-icon-white-background-success {
+  --mat-icon-color: var(--primary);
+  background-color: white;
+  border-style: solid;
+}
+
 .material-icon-on-secondary-container {
   --mat-icon-color: var(--on-secondary-container);
 }

--- a/libs/damap/src/lib/components/dmp/dmp.component.css
+++ b/libs/damap/src/lib/components/dmp/dmp.component.css
@@ -34,6 +34,21 @@
   box-sizing: border-box;
 }
 
+.custom-icon-step {
+  border-radius: 50%;
+  padding: 4px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.number-step-icon {
+  font: var(--body-typography);
+  font-size: 1rem;
+}
+
 .verticalStepper {
   width: 100%;
 }
@@ -50,9 +65,10 @@
 
 @media (max-width: 1300px) {
   ::ng-deep .mat-step-icon {
-    width: 24px;
-    height: 24px;
-    font-size: 0.875rem;
+    width: 20px !important;
+    height: 20px !important;
+    margin-right: 5px !important;
+    font-size: 0.8rem;
   }
 
   .label-container {
@@ -74,7 +90,7 @@
   }
 }
 
-@media (max-width: 760px) {
+@media (max-width: 900px) {
   ::ng-deep .mat-step-icon {
     width: 18px !important;
     height: 18px !important;

--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -7,7 +7,106 @@
       [linear]="false"
       orientation="vertical"
       (selectionChange)="handleStepChange($event)">
-      <mat-step label="{{ 'dmp.steps.project.label' | translate }}">
+      <!-- The logic for the icons in the stepper  -->
+
+      <ng-template matStepperIcon="done" let-index="index">
+        <mat-icon
+          class="material-icon-white-background-primary custom-icon-step"
+          *ngIf="iconsValidatorDone(index, 'check')"
+          >check</mat-icon
+        >
+
+        <mat-icon
+          class="material-icon-white-background-success custom-icon-step outline"
+          *ngIf="iconsValidatorDone(index, 'edit')"
+          >edit</mat-icon
+        >
+        <mat-icon
+          class="custom-icon-step"
+          *ngIf="iconsValidatorDone(index, 'lock')"
+          >lock</mat-icon
+        >
+
+        <mat-icon
+          class="material-icon-white-background-primary custom-icon-step"
+          *ngIf="iconsValidatorDone(index, 'text_snippet')">
+          text_snippet
+        </mat-icon>
+      </ng-template>
+
+      <ng-template matStepperIcon="edit" let-index="index">
+        <mat-icon
+          class="material-icon-white-background-success custom-icon-step"
+          *ngIf="iconsValidatorEdit(index, 'text_snippet')">
+          text_snippet
+        </mat-icon>
+
+        <mat-icon
+          class="material-icon-white-background-primary custom-icon-step"
+          *ngIf="iconsValidatorEdit(index, 'edit')">
+          edit
+        </mat-icon>
+
+        <mat-icon
+          class="material-icon-white-background-primary custom-icon-step"
+          *ngIf="iconsValidatorEdit(index, 'lock')"
+          >lock</mat-icon
+        >
+      </ng-template>
+
+      <ng-template matStepperIcon="number" let-index="index">
+        <mat-icon
+          class="custom-icon-step number-step-icon"
+          *ngIf="iconsValidatorNumber(index, 'number', stepper.selectedIndex)">
+          {{ index + 1 }}
+        </mat-icon>
+
+        <mat-icon
+          class="material-icon-white-background-primary custom-icon-step"
+          *ngIf="iconsValidatorNumber(index, 'edit', stepper.selectedIndex)">
+          edit
+        </mat-icon>
+
+        <mat-icon
+          class="custom-icon-step"
+          *ngIf="
+            iconsValidatorNumber(
+              index,
+              'text_snippet',
+              stepper.selectedIndex,
+              'gray'
+            )
+          ">
+          text_snippet
+        </mat-icon>
+
+        <mat-icon
+          class="material-icon-white-background-success custom-icon-step"
+          *ngIf="
+            iconsValidatorNumber(
+              index,
+              'text_snippet',
+              stepper.selectedIndex,
+              'success'
+            )
+          ">
+          text_snippet
+        </mat-icon>
+
+        <mat-icon
+          class="custom-icon-step"
+          *ngIf="iconsValidatorNumber(index, 'lock', stepper.selectedIndex)"
+          >lock</mat-icon
+        >
+      </ng-template>
+
+      <!-- The steps  -->
+
+      <mat-step
+        label="{{ 'dmp.steps.project.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.project.label')?.completeness > 0
+        ">
         <ng-container *ngIf="selectedStep === 0">
           <app-project-instruction
             (selectionChange)="
@@ -17,7 +116,10 @@
       </mat-step>
       <mat-step
         class="label-container"
-        label="{{ 'dmp.steps.people.label' | translate }}">
+        label="{{ 'dmp.steps.people.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.people.label')?.completeness > 0
+        ">
         <ng-container *ngIf="selectedStep === 1">
           <app-people-instruction
             (selectionChange)="
@@ -25,7 +127,11 @@
             "></app-people-instruction>
         </ng-container>
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.data.specify.label' | translate }}">
+      <mat-step
+        label="{{ 'dmp.steps.data.specify.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.data.specify.label')?.completeness > 0
+        ">
         <ng-container *ngIf="selectedStep === 2">
           <app-specify-data-instruction
             (selectionChange)="
@@ -33,16 +139,28 @@
             "></app-specify-data-instruction>
         </ng-container>
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.documentation.label' | translate }}">
+      <mat-step
+        label="{{ 'dmp.steps.documentation.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.documentation.label')?.completeness > 0
+        ">
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.storage.label' | translate }}">
+      <mat-step
+        label="{{ 'dmp.steps.storage.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.storage.label')?.completeness > 0
+        ">
         <ng-container *ngIf="selectedStep === 4">
           <app-data-storage-instruction
             (selectionChange)="onViewChangeStorage($event)">
           </app-data-storage-instruction>
         </ng-container>
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.legal.label' | translate }}">
+      <mat-step
+        label="{{ 'dmp.steps.legal.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.legal.label')?.completeness > 0
+        ">
         <ng-container *ngIf="selectedStep === 5">
           <app-legal-ethical-instruction
             (selectionChange)="
@@ -50,19 +168,38 @@
             "></app-legal-ethical-instruction>
         </ng-container>
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.licensing.label' | translate }}">
+      <mat-step
+        label="{{ 'dmp.steps.licensing.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.licensing.label')?.completeness > 0
+        ">
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.repositories.label' | translate }}">
+      <mat-step
+        label="{{ 'dmp.steps.repositories.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.repositories.label')?.completeness > 0
+        ">
         <ng-container *ngIf="selectedStep === 7">
           <app-repo-instruction
             (selectionChange)="repoComponent?.onViewChange($event)">
           </app-repo-instruction>
         </ng-container>
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.data.reuse.label' | translate }}">
+      <mat-step
+        label="{{ 'dmp.steps.data.reuse.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.data.reuse.label')?.completeness > 0
+        ">
       </mat-step>
-      <mat-step label="{{ 'dmp.steps.costs.label' | translate }}"> </mat-step>
-      <mat-step label="{{ 'dmp.steps.end.label' | translate }}"> </mat-step>
+      <mat-step
+        label="{{ 'dmp.steps.costs.label' | translate }}"
+        [completed]="
+          completenessLabel('dmp.steps.costs.label')?.completeness > 0
+        "></mat-step>
+      <mat-step
+        label="{{ 'dmp.steps.end.label' | translate }}"
+        [completed]="checkCompletenessForm() === 'completed'">
+      </mat-step>
     </mat-vertical-stepper>
   </div>
 

--- a/libs/damap/src/lib/components/dmp/dmp.module.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.module.ts
@@ -28,6 +28,7 @@ import { SpecifyDataModule } from './specify-data/specify-data.module';
 import { SummaryModule } from './summary/summary.module';
 import { ToggleButtonsModule } from '../../widgets/toggle-buttons/toggle-buttons.module';
 import { VersionModule } from '../version/version.module';
+import { MatIconModule } from '@angular/material/icon';
 
 // required for AOT compilation
 export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
@@ -80,6 +81,7 @@ export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
     InfoCardComponent,
     // Materials
     MatStepperModule,
+    MatIconModule,
     DmpActionsModule,
   ],
   declarations: [DmpComponent],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->
https://github.com/tuwien-csd/damap-frontend/issues/35

## Description
This PR add new icons to the stepper, each icon has a meaning.


<!-- Please select a type that best describes your PR -->
Add new icons to the steps in the stepper to indicate a state for the state. 
The step number is displayed if the step has not been modified.
The lock icon indicates that the step is locked due to a requirement in a previous step.
The pencil icon indicates that the step is being edited. 
The outline pencil icon indicates that the step may be missing information.
The check icon indicates that the step is complete.
The paper icon is set in the summary step.

<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
The stepper when no step is being edited
![image](https://github.com/user-attachments/assets/8bb11aba-8da2-4fcd-afbb-e2f534086aa1)
The stepper when all the steps are completed
![image](https://github.com/user-attachments/assets/3497f0c1-36bb-4203-b091-fae70866511c)
The stepper when some steps have been started filled but still missing information to be full complete
![image](https://github.com/user-attachments/assets/6a7080e7-126f-4140-a770-f3f2d1252b56)



<!-- Changes introduced by this PR - what happened before, what happens now -->
This is how was the stepper icons before:
![image](https://github.com/user-attachments/assets/ba385ccd-f60b-4ede-ae10-712d20f353d6)


#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-35
