### PR TITLE
Fix: Display multiple contributor roles in UI

### DIFF
--- a/libs/damap/src/lib/components/dmp/people/people.component.html
+++ b/libs/damap/src/lib/components/dmp/people/people.component.html
@@ -20,7 +20,7 @@
           </app-person-search>
         </div>
         <div class="service-select-container">
-          <mat-form-field appearance="outline">
+          <mat-form-field>
             <mat-label>{{
               "dmp.steps.people.search.service" | translate
             }}</mat-label>
@@ -146,7 +146,7 @@
                   <mat-label>{{
                     "dmp.steps.people.contributor.role" | translate
                   }}</mat-label>
-                  <mat-select formControlName="role">
+                  <mat-select formControlName="roles" multiple>
                     <mat-option
                       *ngFor="let role of roles | keyvalue"
                       [value]="role.key">
@@ -281,7 +281,7 @@
                   <mat-label>{{
                     "dmp.steps.people.contributor.role" | translate
                   }}</mat-label>
-                  <mat-select formControlName="role">
+                  <mat-select formControlName="roles" multiple>
                     <mat-option
                       *ngFor="let role of roles | keyvalue"
                       [value]="role.key">

--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -164,6 +164,7 @@ export class PeopleComponent implements OnInit, OnDestroy {
         identifier: this.form.value.personId,
         type: IdentifierType.ORCID,
       },
+      roles: this.form.value.roles,
     };
 
     this.contributorToUpdate.emit({

--- a/libs/damap/src/lib/domain/contributor.ts
+++ b/libs/damap/src/lib/domain/contributor.ts
@@ -10,8 +10,8 @@ interface Contributor {
   readonly mbox: string;
   readonly affiliation: string;
   readonly affiliationId: Identifier;
+  roles: ContributorRole[];
   contact: boolean;
-  role: ContributorRole;
   roleInProject: string;
 }
 

--- a/libs/damap/src/lib/mocks/access-mocks.ts
+++ b/libs/damap/src/lib/mocks/access-mocks.ts
@@ -13,7 +13,7 @@ export const mockAccess: Access = {
   affiliation: 'TU Wien',
   affiliationId: { identifier: 'XXX', type: IdentifierType.ROR },
   contact: true,
-  role: null,
+  roles: [],
   roleInProject: undefined,
   access: FunctionRole.EDITOR,
 };

--- a/libs/damap/src/lib/mocks/contributor-mocks.ts
+++ b/libs/damap/src/lib/mocks/contributor-mocks.ts
@@ -1,6 +1,6 @@
-import { IdentifierType } from '../domain/enum/identifier-type.enum';
 import { Contributor } from '../domain/contributor';
 import { ContributorRole } from '../domain/enum/contributor-role.enum';
+import { IdentifierType } from '../domain/enum/identifier-type.enum';
 
 export const mockContact: Contributor = {
   id: 77,
@@ -12,7 +12,7 @@ export const mockContact: Contributor = {
   affiliation: 'TU Wien',
   affiliationId: { identifier: 'XXX', type: IdentifierType.ROR },
   contact: true,
-  role: null,
+  roles: [],
   roleInProject: 'Project leader',
 };
 
@@ -26,7 +26,7 @@ export const mockContributor1: Contributor = {
   affiliation: 'TU Wien',
   affiliationId: { identifier: 'XXX', type: IdentifierType.ROR },
   contact: false,
-  role: ContributorRole.EDITOR,
+  roles: [ContributorRole.EDITOR, ContributorRole.DATA_CURATOR],
   roleInProject: 'Project manager',
 };
 
@@ -43,6 +43,6 @@ export const mockContributor2: Contributor = {
   affiliation: 'TU Wien',
   affiliationId: { identifier: 'XXX', type: IdentifierType.ROR },
   contact: false,
-  role: ContributorRole.PROJECT_MANAGER,
+  roles: [ContributorRole.PROJECT_MANAGER, ContributorRole.DATA_MANAGER],
   roleInProject: 'Project manager',
 };

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -5,6 +5,7 @@ import {
   FormGroup,
   UntypedFormArray,
   UntypedFormBuilder,
+  UntypedFormControl,
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
@@ -320,9 +321,8 @@ export class FormService {
   }
 
   public addContributorToForm(contributor: Contributor, contact = false) {
-    const contributorFormGroup = this.createContributorFormGroup();
-    contributorFormGroup.patchValue(contributor);
-    contributorFormGroup.patchValue({ contact });
+    contributor.contact = contact;
+    const contributorFormGroup = this.mapContributorToFormGroup(contributor);
     (this.form.get('contributors') as UntypedFormArray).push(
       contributorFormGroup,
     );
@@ -608,9 +608,9 @@ export class FormService {
       lastName: ['', Validators.maxLength(this.TEXT_SHORT_LENGTH)],
       mbox: ['', Validators.maxLength(this.TEXT_SHORT_LENGTH)],
       personId: [null],
-      role: [null],
       roleInProject: [''],
       universityId: [null],
+      roles: new UntypedFormControl([]),
     });
   }
 
@@ -618,7 +618,12 @@ export class FormService {
     contributor: Contributor,
   ): UntypedFormGroup {
     const formGroup = this.createContributorFormGroup();
-    formGroup.patchValue(contributor);
+
+    formGroup.patchValue({
+      ...contributor,
+      roles: contributor.roles || [],
+    });
+
     return formGroup;
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Updated the contributor selection dropdown with multi-select functionality.
Displayed assigned roles correctly in both the UI and exported templates.

#### What does this PR do?

![Screenshot 2025-02-24 at 09 50 01](https://github.com/user-attachments/assets/0248de9c-79d6-443f-8b1c-1c430c7e75df)


#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
