### PR TITLE
Global: make no datasets message more clear for step 7/8

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -467,7 +467,8 @@
         }
       }
     },
-    "nodatasets": "Please define datasets first.",
+    "nodatasets": "Please declare any new or existing dataset first.",
+    "nonewdataset": "Please declare a produced (i.e. new) dataset first.",
     "success": {
       "update": "DMP was updated!",
       "save": "DMP was saved!",

--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -298,7 +298,7 @@
       </ng-container>
     </ng-container>
     <ng-container *ngIf="selectedStep === 6">
-      <ng-container *ngIf="showStepIfNewDatasets; else noDatasets">
+      <ng-container *ngIf="showStepIfNewDatasets; else noNewDataset">
         <app-dmp-licenses
           [dmpForm]="dmpForm"
           [datasets]="datasets"></app-dmp-licenses>
@@ -308,7 +308,7 @@
       </ng-container>
     </ng-container>
     <ng-container *ngIf="selectedStep === 7">
-      <ng-container *ngIf="showStepIfNewDatasets; else noDatasets">
+      <ng-container *ngIf="showStepIfNewDatasets; else noNewDataset">
         <app-dmp-repo
           #repo
           [dmpForm]="dmpForm"
@@ -323,7 +323,7 @@
       </ng-container>
     </ng-container>
     <ng-container *ngIf="selectedStep === 8">
-      <ng-container *ngIf="showStep; else noDatasets">
+      <ng-container *ngIf="showStepIfNewDatasets; else noNewDataset">
         <app-dmp-reuse
           [reuseStep]="reuseStep"
           [datasets]="datasets"></app-dmp-reuse>
@@ -352,7 +352,15 @@
 </div>
 
 <ng-template #noDatasets>
-  {{ "dmp.nodatasets" | translate }}
+  <a href="javascript:void(0)" (click)="onNewDatasetClick()">
+    {{ "dmp.nodatasets" | translate }}
+  </a>
+</ng-template>
+
+<ng-template #noNewDataset>
+  <a href="javascript:void(0)" (click)="onNewDatasetClick()">
+    {{ "dmp.nonewdataset" | translate }}
+  </a>
 </ng-template>
 
 <app-actions

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -136,6 +136,11 @@ export class DmpComponent implements OnInit, OnDestroy {
     });
   }
 
+  onNewDatasetClick() {
+    this.stepper.selectedIndex = 2;
+    this.cdr.detectChanges();
+  }
+
   onStepChange(selectedStep: number) {
     this.selectedStep = selectedStep;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
UX Improvement
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
Clarified the error message for steps 7/8 to notify the user that a new dataset must be created first to unlock those steps.
Clicking these error messages (and the ones where any dataset must be defined) routes to step 3 (specify research data).
<!-- Changes introduced by this PR - what happened before, what happens now -->

closes GH-393<!-- insert issue number -->
