### PR TITLE
Manual Project: Make Update Project button more user friendly (feedba…

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -2,12 +2,17 @@
   "dmp": {
     "steps": {
       "project": {
+        "success": "Updated project information!",
         "input": {
           "title": "Project title",
           "description": "Project description",
-          "button": "Update project",
-          "acronym": "Update acronym",
-          "date": "Enter start and end date",
+          "info": "Project information",
+          "button": {
+            "existing": "Update project info",
+            "new": "Add project"
+          },
+          "acronym": "Acronym",
+          "date": "Start and end date",
           "datehint": "DD/MM/YYYY – DD/MM/YYYY"
         },
         "manual.input": "Input project manually",

--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.html
@@ -1,5 +1,5 @@
 <mat-label class="label-title mat-title-large" id="example-radio-group-label">{{
-  "dmp.steps.project.input.title" | translate
+  "dmp.steps.project.input.info" | translate
 }}</mat-label>
 <mat-card class="manual-project-input-card card-shadow">
   <mat-card-content>
@@ -9,7 +9,7 @@
           class="input-full"
           [control]="title"
           label="{{
-            'dmp.steps.project.input.button' | translate
+            'dmp.steps.project.input.title' | translate
           }}"></app-input-wrapper>
         <app-input-wrapper
           class="input-fill"
@@ -47,7 +47,11 @@
         mat-raised-button
         [disabled]="form.invalid"
         (click)="updateProject()">
-        {{ "dmp.steps.project.input.button" | translate }}
+        {{
+          project !== null
+            ? ("dmp.steps.project.input.button.existing" | translate)
+            : ("dmp.steps.project.input.button.new" | translate)
+        }}
       </button>
     </form>
   </mat-card-content>

--- a/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/manual-project-input/manual-project-input.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/forms';
 
 import { Project } from '../../../../domain/project';
+import { FeedbackService } from '../../../../services/feedback.service';
 
 @Component({
   selector: 'app-manual-project-input',
@@ -35,6 +36,8 @@ export class ManualProjectInputComponent implements OnChanges {
     acronym: new UntypedFormControl('', [Validators.maxLength(255)]),
   });
 
+  constructor(private feedbackService: FeedbackService) {}
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.project && !this.project?.universityId) {
       this.form.patchValue(this.project);
@@ -42,6 +45,9 @@ export class ManualProjectInputComponent implements OnChanges {
   }
 
   updateProject(): void {
+    if (this.project !== null) {
+      this.feedbackService.success('dmp.steps.project.success');
+    }
     const project = this.form.getRawValue();
     this.projectUpdate.emit(project);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Feature
#### What does this PR do?
Made "update project" button more user friendly: 
- Button reads "Update project info" if it is meant to update the info of an already existing project, "Add Project" if no selected project exists
- Fixed some labels where the user inputs the project information manually for clarity
- User now receives feedback when the project information has been updated (in case of only changing the description for instance, before no feedback was given)
<!-- Changes introduced by this PR - what happened before, what happens now -->

closes GH-383<!-- insert issue number -->
