### PR TITLE
Licensing: Add no/custom license & selector for restricted datasets

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -548,6 +548,14 @@
       "library": "Library"
     },
     "license": {
+      "nolicense": {
+        "name": "No License",
+        "description": "This should be selected when no license is granted."
+      },
+      "custom": {
+        "name": "Custom License",
+        "description": "This should be selected when a custom license is granted."
+      },
       "agpl1": {
         "name": "Affero General Public License v1.0 only",
         "description": "The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software."

--- a/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
+++ b/libs/damap/src/lib/components/dmp/licenses/licenses.component.html
@@ -54,7 +54,9 @@
               {{ "dmp.steps.licensing.warning.legalRestrictions" | translate }}
             </ng-container>
           </div>
-          <mat-card-content>
+        </ng-container>
+        <mat-card-content>
+          <ng-container *ngIf="dataset.value.dataAccess !== accessType.CLOSED">
             <div class="mat-card-container">
               <mat-form-field class="full-width">
                 <mat-label>{{
@@ -63,7 +65,7 @@
                 <mat-select formControlName="license">
                   <mat-option
                     *ngFor="let license of licenses"
-                    [value]="license.id | translate">
+                    [value]="license.id">
                     {{ license.name | translate }}
                   </mat-option>
                 </mat-select>
@@ -73,8 +75,8 @@
                   setLicenseSelectorResult($event, i)
                 "></app-license-wizard>
             </div>
-          </mat-card-content>
-        </ng-container>
+          </ng-container>
+        </mat-card-content>
 
         <mat-card-content
           class="card-content-estimation"

--- a/libs/damap/src/lib/widgets/license-wizard/license-wizard-list.ts
+++ b/libs/damap/src/lib/widgets/license-wizard/license-wizard-list.ts
@@ -30,7 +30,6 @@ import { LicenseDetails } from '../../domain/license-details';
  compatibility - list of licenses (using code) which are compatible, some licenses came without this field
 
  ***/
-
 export const agpl1 = {
   id: 'AGPL1',
   name: 'license.wizard.license.agpl1.name',
@@ -578,6 +577,30 @@ export const pddl = {
   categories: ['public', 'data', 'public-domain'],
   labels: ['public'],
 };
+export const nolicense = {
+  id: 'NOLICENSE',
+  name: 'license.wizard.license.nolicense.name',
+  priority: null,
+  available: null,
+  url: null,
+  description: 'license.wizard.license.nolicense.description',
+  categories: [],
+  labels: null,
+  code: null,
+  compatibility: null,
+};
+export const custom = {
+  id: 'CUSTOM',
+  name: 'license.wizard.license.custom.name',
+  priority: null,
+  available: null,
+  url: null,
+  description: 'license.wizard.license.custom.description',
+  categories: [],
+  labels: null,
+  code: null,
+  compatibility: null,
+};
 
 export const LicenseDefinitions: LicenseDetails[] = [
   agpl1,
@@ -621,6 +644,8 @@ export const LicenseDefinitions: LicenseDetails[] = [
   odbl,
   odcBy,
   pddl,
+  nolicense,
+  custom,
 ];
 
 export const SoftwareLicenses: LicenseDetails[] = [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix
#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->
Display license selector for datasets with restricted access as well (before: only open access)
Added the options "no license" and "custom license":
![grafik](https://github.com/user-attachments/assets/5c72dd91-bb23-469e-9bdb-3e2541d95af6)


#### Dependencies
Backend changes necessary: https://github.com/tuwien-csd/damap-backend/pull/373
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->



closes GH-448<!-- insert issue number -->
