### PR TITLE
feat: improve info card visibility

### DIFF
--- a/libs/damap/src/lib/components/dmp/dmp.component.css
+++ b/libs/damap/src/lib/components/dmp/dmp.component.css
@@ -5,6 +5,7 @@
   gap: 20px;
   margin: 20px;
   padding-bottom: 80px;
+  padding-top: 10px;
 }
 
 .steps-container {

--- a/libs/damap/src/lib/widgets/info-card/info-card.component.css
+++ b/libs/damap/src/lib/widgets/info-card/info-card.component.css
@@ -3,13 +3,26 @@
   border: 1px solid #ccc;
   border-radius: 8px;
   margin: 0 20px;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: var(--primary-lightest);
+  margin-bottom: 20px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.card-controls {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
 }
 
 .close-button {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  z-index: 1;
+  position: relative;
   background: transparent;
   border: none;
   color: var(--neutral-color-medium-light);
@@ -70,6 +83,29 @@
   font-weight: 300;
   color: var(--user-navbar-color);
   padding: 16px 16px;
+}
+
+.info-box.collapsed {
+  padding: 8px;
+  cursor: pointer;
+}
+
+.info-box.collapsed .flex-row-container {
+  justify-content: center;
+}
+
+.info-box.collapsed .info-box-container {
+  display: none;
+}
+
+.expand-collapse-btn {
+  background: transparent;
+  border: none;
+  color: var(--primary-color);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  margin-left: auto;
 }
 
 .mat-content {

--- a/libs/damap/src/lib/widgets/info-card/info-card.component.html
+++ b/libs/damap/src/lib/widgets/info-card/info-card.component.html
@@ -1,12 +1,20 @@
 <mat-card
   appearance="outlined"
   *ngIf="isIntroShow"
-  class="info-box mat-icon-shadow custom-card">
-  <button (click)="closeIntro()" mat-icon-button class="close-button">
-    <mat-icon class="material-icon-primary close-icon" matSuffix>
-      close
-    </mat-icon>
-  </button>
+  [ngClass]="{
+    'info-box': true,
+    'mat-icon-shadow': true,
+    'custom-card': true,
+    collapsed: isCollapsed,
+  }"
+  (click)="isCollapsed ? toggleCollapse() : null">
+  <div class="card-controls">
+    <button (click)="closeIntro()" mat-icon-button class="close-button">
+      <mat-icon class="material-icon-primary close-icon" matSuffix>
+        close
+      </mat-icon>
+    </button>
+  </div>
   <mat-card-content class="mat-content">
     <div class="flex-row-container">
       <section>
@@ -29,5 +37,13 @@
         {{ instructions | translate }}
       </div>
     </div>
+    <button
+      (click)="toggleCollapse()"
+      mat-button
+      *ngIf="isCollapsed"
+      class="expand-collapse-btn">
+      <mat-icon class="material-icon-primary">keyboard_arrow_down</mat-icon>
+      <span>Show details</span>
+    </button>
   </mat-card-content>
 </mat-card>

--- a/libs/damap/src/lib/widgets/info-card/info-card.component.ts
+++ b/libs/damap/src/lib/widgets/info-card/info-card.component.ts
@@ -1,9 +1,10 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
+
 import { CommonModule } from '@angular/common';
+import { InfoBoxDetails } from '../../domain/infoBox-details';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { InfoBoxDetails } from '../../domain/infoBox-details';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -26,6 +27,7 @@ export class InfoCardComponent implements OnInit, OnChanges {
   public instructions: string;
   public summaryLine: string;
   public isIntroShow: boolean = true;
+  public isCollapsed: boolean = false;
   public icon: string | number;
 
   ngOnInit(): void {
@@ -54,5 +56,9 @@ export class InfoCardComponent implements OnInit, OnChanges {
 
   openIntro(): void {
     this.isIntroShow = true;
+  }
+
+  toggleCollapse(): void {
+    this.isCollapsed = !this.isCollapsed;
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

This PR introduces a sticky info-card that remains visible at the top of the viewport, addressing the issue where the info-card was not accessible when working on lower steps, especially on smaller screens.

#### What does this PR do?

Sticky Position: the info-card is fixed at the top during scrolling, ensuring constant visibility.
Collapse/Expand Functionality: users can minimize or expand the info-card as needed.
Styling Enhancements: added subtle shadow, appropriate z-index, and a background color.

#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

Persistent access to the info-card without the need to scroll up.
Usability on smaller screens by allowing users to control the info-card's visibility.

#### Idea

![Screenshot 2025-05-23 at 16 40 34](https://github.com/user-attachments/assets/2cd42117-b9d1-4816-9ece-e2b3479d273b)


### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-461
