### PR TITLE
Fix: DOI serach validation and error display

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -112,7 +112,7 @@
           "button": {
             "add": {
               "manual": "Add dataset manually",
-              "doi": "Find dataset"
+              "doi": "Add dataset"
             }
           },
           "table": {

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.html
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.html
@@ -1,20 +1,18 @@
-<form>
+<form [formGroup]="form">
   <div class="form-row">
     <app-search-field
       class="full-width"
       [label]="'dmp.steps.data.specify.doi.search'"
       [placeholder]="'10.5281/zenodo.3885730'"
-      [control]="doi"
+      [control]="form.get('doi')"
       [errorMessage]="'form.error.doi'"
       (searchChange)="searchChange($event)"></app-search-field>
     <button
       mat-raised-button
       class="button-color-primary"
       type="submit"
-      (click)="search(searchTerm)"
-      [disabled]="
-        !searchTerm || doi.invalid || loading === loadingState.LOADING
-      ">
+      (click)="search()"
+      [disabled]="form.invalid || loading === loadingState.LOADING">
       {{ "dmp.steps.data.specify.button.add.doi" | translate }}
     </button>
   </div>

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.spec.ts
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.spec.ts
@@ -41,12 +41,13 @@ describe('DoiSearchComponent', () => {
   });
 
   it('should en-/disable the form control depending on the loading state', () => {
-    spyOn(component.doi, 'setValue');
-    spyOn(component.doi, 'enable');
-    spyOn(component.doi, 'disable');
+    const doiControl = component.form.get('doi');
+    spyOn(doiControl, 'setValue');
+    spyOn(doiControl, 'enable');
+    spyOn(doiControl, 'disable');
 
     component.loading = LoadingState.NOT_LOADED;
-    expect(component.doi.disabled).toBe(false);
+    expect(doiControl.disabled).toBe(false);
 
     component.loading = LoadingState.LOADING;
     component.ngOnChanges({
@@ -57,7 +58,7 @@ describe('DoiSearchComponent', () => {
       ),
     });
     expect(component.loading).toBe(LoadingState.LOADING);
-    expect(component.doi.disable).toHaveBeenCalledTimes(1);
+    expect(doiControl.disable).toHaveBeenCalledTimes(1);
 
     component.loading = LoadingState.LOADED;
     component.ngOnChanges({
@@ -67,15 +68,23 @@ describe('DoiSearchComponent', () => {
         false,
       ),
     });
-    expect(component.doi.setValue).toHaveBeenCalledTimes(1);
-    expect(component.doi.enable).toHaveBeenCalledTimes(1);
+    expect(doiControl.setValue).toHaveBeenCalledTimes(1);
+    expect(doiControl.enable).toHaveBeenCalledTimes(1);
   });
 
-  it('extract the correct doi search term and search for it', () => {
+  it('should emit search term when form is valid', () => {
     spyOn(component.termToSearch, 'emit');
-    const doi = ' doi: 10.12345/12345 ';
-    const searchTerm = '10.12345/12345';
-    component.search(doi);
-    expect(component.termToSearch.emit).toHaveBeenCalledOnceWith(searchTerm);
+    const doi = '10.12345/12345';
+    component.form.get('doi').setValue(doi);
+    component.search();
+    expect(component.termToSearch.emit).toHaveBeenCalledOnceWith(doi);
+  });
+
+  it('should not emit search term when form is invalid', () => {
+    spyOn(component.termToSearch, 'emit');
+    const invalidDoi = 'invalid-doi';
+    component.form.get('doi').setValue(invalidDoi);
+    component.search();
+    expect(component.termToSearch.emit).not.toHaveBeenCalled();
   });
 });

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
@@ -6,10 +6,11 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
+import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+
 import { Dataset } from '../../domain/dataset';
-import { UntypedFormControl } from '@angular/forms';
-import { doiValidator } from '../../validators/doi.validator';
 import { LoadingState } from '../../domain/enum/loading-state.enum';
+import { doiValidator } from '../../validators/doi.validator';
 
 @Component({
   selector: 'app-doi-search',
@@ -23,35 +24,43 @@ export class DoiSearchComponent implements OnChanges {
   @Output() termToSearch = new EventEmitter<string>();
   @Output() datasetToAdd = new EventEmitter<Dataset>();
 
-  doi = new UntypedFormControl('', {
-    validators: doiValidator(),
-    updateOn: 'blur',
+  form = new UntypedFormGroup({
+    doi: new UntypedFormControl('', {
+      validators: doiValidator(),
+      updateOn: 'change',
+    }),
   });
 
   readonly loadingState: any = LoadingState;
-  searchTerm: string = '';
+
+  constructor() {
+    this.form.get('doi').valueChanges.subscribe(value => {
+      if (value && !this.form.get('doi').touched) {
+        this.form.get('doi').markAsTouched();
+      }
+    });
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.loading) {
       if (this.loading === LoadingState.LOADED) {
-        this.doi.setValue('');
+        this.form.reset();
       }
       if (this.loading === LoadingState.LOADING) {
-        this.doi.disable();
+        this.form.disable();
       } else {
-        this.doi.enable();
+        this.form.enable();
       }
     }
   }
 
-  search(term: string) {
-    if (term.trim()) {
-      term = term.substring(term.indexOf('10.')).trim();
-      this.termToSearch.emit(term);
+  search() {
+    if (this.form.valid) {
+      this.termToSearch.emit(this.form.get('doi').value.trim());
     }
   }
 
   searchChange(searchInput: string) {
-    this.searchTerm = searchInput;
+    this.form.patchValue({ doi: searchInput });
   }
 }

--- a/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
+++ b/libs/damap/src/lib/widgets/doi-search/doi-search.component.ts
@@ -6,7 +6,11 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import {
+  UntypedFormControl,
+  UntypedFormGroup,
+  Validators,
+} from '@angular/forms';
 
 import { Dataset } from '../../domain/dataset';
 import { LoadingState } from '../../domain/enum/loading-state.enum';
@@ -26,7 +30,7 @@ export class DoiSearchComponent implements OnChanges {
 
   form = new UntypedFormGroup({
     doi: new UntypedFormControl('', {
-      validators: doiValidator(),
+      validators: [Validators.required, doiValidator()],
       updateOn: 'change',
     }),
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Add immediate validation when user enters a DOI
Show error messages right away when DOI is invalid
Prevent search with invalid DOIs
Update button text 
Use UntypedFormControl to match existing codebase patterns


<img width="756" alt="Screenshot 2025-05-30 at 11 59 17" src="https://github.com/user-attachments/assets/cffc215c-38fb-47d5-b09e-31b3cdefe17a" />

<img width="765" alt="Screenshot 2025-05-30 at 11 58 57" src="https://github.com/user-attachments/assets/9448051b-7db2-4c40-8e9f-13e6b30dca41" />


Test with DOI: 10.5281/zenodo.3885730

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
