### PR TITLE
Access: Add option to give ownership rights

### DIFF
--- a/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
+++ b/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
@@ -17,6 +17,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
   ],
   templateUrl: './landing-page.component.html',
   styleUrl: './landing-page.component.css',
+  standalone: true,
 })
 export class LandingPageComponent implements OnInit {
   constructor(private translate: TranslateService) {}

--- a/libs/damap/src/assets/i18n/access/en.json
+++ b/libs/damap/src/assets/i18n/access/en.json
@@ -3,9 +3,11 @@
     "button": {
       "plans": "Go back to DMP overview"
     },
-    "editor": "Editor",
-    "owner": "Owner",
-    "list": "Only contributors can be assigned editing rights for a DMP. ",
-    "info": "Please note that simultaneous editing of a DMP can lead to data loss as changes may overwrite each other. Please make sure that you are the only one editing the dmp at the moment."
+    "no_rights": "Default setting. The user will not be able to see or interact with the DMP.",
+    "editor": "Editor rights grant the user permissions to see the DMP and make changes to it. There are no restrictions on the kind of changes this user can make, bar deleting the DMP. The user can not however, assign viewing or editing permissions.",
+    "owner": "Owners can view, write, delete and assign permissions for DMPs. They are also capable of creating new owners - handle with care, new owners can remove old ones.",
+    "list": "Only contributors in your universities database can be assigned editing rights for a DMP. ",
+    "info": "Please note that simultaneous editing of a DMP can lead to data loss as changes may overwrite each other. Please make sure that you are the only one editing the dmp at the moment.",
+    "noOwner": "Only owners of the DMP are allowed to change access rights."
   }
 }

--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -453,8 +453,8 @@
         "storage": {
           "allinfo": "All information necessary provided.",
           "nonestored": "No datasets will be stored, as no produced or reused datasets have been specified.",
-          "missingstorage": "Some data is not stored.",
-          "missingexplanation": "Explanation for using external storage is missing."
+          "missingstorage": "Some datasets do not have storages assigned.",
+          "missingexplanation": " Explanation for using external storage is missing."
         },
         "licensing": {
           "complete": "All information necessary provided.",

--- a/libs/damap/src/lib/auth/auth.service.ts
+++ b/libs/damap/src/lib/auth/auth.service.ts
@@ -53,4 +53,9 @@ export class AuthService {
   logout() {
     this.oAuthService.logOut();
   }
+
+  getId(): string {
+    const claims = this.oAuthService.getIdentityClaims();
+    return claims['personID'];
+  }
 }

--- a/libs/damap/src/lib/components/access/access.component.css
+++ b/libs/damap/src/lib/components/access/access.component.css
@@ -11,6 +11,15 @@
   margin-right: 1rem;
 }
 
-.owner mat-icon {
+.user mat-icon {
   margin-right: -0.5rem;
+}
+
+.radio-buttons {
+  display: flex;
+  flex-direction: column;
+}
+
+.role-text {
+  margin-right: 2px;
 }

--- a/libs/damap/src/lib/components/access/access.component.html
+++ b/libs/damap/src/lib/components/access/access.component.html
@@ -1,38 +1,51 @@
 <div id="access-wrapper">
-  <div *ngIf="dmp$ | async as dmp">
-    <h2>{{ dmp.project?.title || "DMP ID: " + dmp.id }}</h2>
-  </div>
-  <div class="action-buttons">
-    <button mat-raised-button [routerLink]="'/plans'">
-      <mat-icon>chevron_left</mat-icon>
-      {{ "access.button.plans" | translate }}
-    </button>
-    <button
-      mat-raised-button
-      class="button-color-primary"
-      [routerLink]="'/dmp/' + id">
-      {{ "versions.view.button.goto.latest" | translate }}
-    </button>
-  </div>
-  <app-info-message
-    >{{ "access.list" | translate
-    }}{{ "access.info" | translate }}</app-info-message
-  >
-  <div class="access-list" *ngFor="let access of accesses$ | async">
-    <damap-person-card [person]="access">
-      <div *ngIf="access.access !== accessType.OWNER; else owner">
-        <mat-checkbox
-          [checked]="access.access === accessType.EDITOR"
-          (change)="editorToggle($event, access)">
-          {{ "access.editor" | translate }}
-        </mat-checkbox>
-      </div>
-      <ng-template #owner>
-        <div class="owner">
-          <mat-icon class="mat-icon-style material-icon-primary">star</mat-icon>
-          {{ "access.owner" | translate }}
+  <div *ngIf="isOwner$ | async; else noOwner">
+    <div *ngIf="dmp$ | async as dmp">
+      <h2>{{ dmp.project?.title || "DMP ID: " + dmp.id }}</h2>
+    </div>
+    <div class="action-buttons">
+      <button mat-raised-button [routerLink]="'/plans'">
+        <mat-icon>chevron_left</mat-icon>
+        {{ "access.button.plans" | translate }}
+      </button>
+      <button
+        mat-raised-button
+        class="button-color-primary"
+        [routerLink]="'/dmp/' + id">
+        {{ "versions.view.button.goto.latest" | translate }}
+      </button>
+    </div>
+    <app-info-message
+      >{{ "access.list" | translate
+      }}{{ "access.info" | translate }}</app-info-message
+    >
+    <div class="access-list" *ngFor="let access of accesses$ | async">
+      <damap-person-card [person]="access">
+        <div *ngIf="access.universityId !== this.userId; else user">
+          <mat-radio-group
+            class="radio-buttons"
+            [(ngModel)]="access.access"
+            (change)="toggleAccess($event, access)">
+            <mat-radio-button *ngFor="let role of roles" [value]="role">
+              <span class="role-text">{{ role }}</span>
+              <app-tooltip
+                [tooltip]="'access.' + role.toLocaleLowerCase()"></app-tooltip>
+            </mat-radio-button>
+          </mat-radio-group>
         </div>
-      </ng-template>
-    </damap-person-card>
+        <ng-template #user>
+          <div class="user">
+            <mat-icon class="mat-icon-style material-icon-primary"
+              >star</mat-icon
+            >
+            {{ access.access }}
+          </div>
+        </ng-template>
+      </damap-person-card>
+    </div>
   </div>
+
+  <ng-template #noOwner>
+    <app-info-message>{{ "access.noOwner" | translate }}</app-info-message>
+  </ng-template>
 </div>

--- a/libs/damap/src/lib/components/access/access.component.spec.ts
+++ b/libs/damap/src/lib/components/access/access.component.spec.ts
@@ -16,6 +16,7 @@ import { PersonCardComponent } from '../../widgets/person-card/person-card.compo
 import { TranslateTestingModule } from '../../testing/translate-testing/translate-testing.module';
 import { completeDmp } from '../../mocks/dmp-mocks';
 import { mockAccess } from '../../mocks/access-mocks';
+import { MatRadioChange } from '@angular/material/radio';
 
 describe('AccessComponent', () => {
   let component: AccessComponent;
@@ -66,17 +67,19 @@ describe('AccessComponent', () => {
 
   it('should create editor', () => {
     backendSpy.createAccess.and.returnValue(of(mockAccess));
-    const $event = new MatCheckboxChange();
-    $event.checked = true;
-    component.editorToggle($event, mockAccess);
+    const $event = {
+      value: mockAccess,
+    } as MatRadioChange;
+    component.toggleAccess($event, mockAccess);
     expect(backendSpy.createAccess).toHaveBeenCalledTimes(1);
   });
 
   it('should delete editor', () => {
     backendSpy.deleteAccess.and.returnValue(EMPTY);
-    const $event = new MatCheckboxChange();
-    $event.checked = false;
-    component.editorToggle($event, mockAccess);
+    const $event = {
+      value: mockAccess,
+    } as MatRadioChange;
+    component.toggleAccess($event, mockAccess);
     expect(backendSpy.deleteAccess).toHaveBeenCalledOnceWith(mockAccess.id);
   });
 });

--- a/libs/damap/src/lib/components/access/access.component.ts
+++ b/libs/damap/src/lib/components/access/access.component.ts
@@ -6,15 +6,21 @@ import { FunctionRole } from '../../domain/enum/function-role.enum';
 import { Observable } from 'rxjs';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { PersonCardComponent } from '../../widgets/person-card/person-card.component';
-import {
-  MatCheckboxChange,
-  MatCheckboxModule,
-} from '@angular/material/checkbox';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { Dmp } from '../../domain/dmp';
 import { MatButtonModule } from '@angular/material/button';
 import { InfoMessageModule } from '../../widgets/info-message/info-message.module';
+import { AuthService } from '../../auth/auth.service';
+import { map } from 'rxjs/operators';
+import {
+  MatRadioButton,
+  MatRadioChange,
+  MatRadioGroup,
+} from '@angular/material/radio';
+import { FormsModule } from '@angular/forms';
+import { TooltipModule } from '../../widgets/tooltip/tooltip.module';
 
 @Component({
   selector: 'damap-access',
@@ -27,6 +33,10 @@ import { InfoMessageModule } from '../../widgets/info-message/info-message.modul
     MatIconModule,
     MatButtonModule,
     InfoMessageModule,
+    MatRadioGroup,
+    MatRadioButton,
+    FormsModule,
+    TooltipModule,
   ],
   templateUrl: './access.component.html',
   styleUrls: ['./access.component.css'],
@@ -34,14 +44,18 @@ import { InfoMessageModule } from '../../widgets/info-message/info-message.modul
 })
 export class AccessComponent implements OnInit {
   accesses$: Observable<Access[]>;
+  isOwner$: Observable<boolean>;
   dmp$: Observable<Dmp>;
   id: number;
-  readonly accessType: any = FunctionRole;
+  protected readonly FunctionRole = FunctionRole;
+  roles = Object.values(FunctionRole);
+  userId: string;
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private backendService: BackendService,
+    private authService: AuthService,
   ) {}
 
   ngOnInit(): void {
@@ -52,22 +66,42 @@ export class AccessComponent implements OnInit {
     } else {
       this.router.navigate(['/']);
     }
+
+    this.userId = this.authService.getId();
+
+    this.isOwner$ = this.accesses$.pipe(
+      map(accesses =>
+        accesses
+          .filter(access => access.universityId === this.userId)
+          .some(access => access.access === FunctionRole.OWNER),
+      ),
+    );
   }
 
   private getAccess(id: number) {
-    this.accesses$ = this.backendService.getAccess(id);
+    this.accesses$ = this.backendService.getAccess(id).pipe(
+      map(accesses => {
+        return accesses.map(access => {
+          // Frontend extension to deal with no access entities, since the backend doesnt have a no rights field
+          if (access.access === null || access.access === undefined) {
+            access.access = FunctionRole.NO_RIGHTS;
+          }
+          return access;
+        });
+      }),
+    );
   }
 
-  editorToggle($event: MatCheckboxChange, access: Access): void {
-    if ($event.checked) {
-      // create new access
+  toggleAccess($event: MatRadioChange, access: Access): void {
+    if ($event.value === FunctionRole.NO_RIGHTS && access.id) {
+      // No_Rights is not in the backend, therefore we just delete the access
+      this.backendService.deleteAccess(access.id).subscribe();
+    } else {
       access.dmpId = this.id;
-      access.access = FunctionRole.EDITOR;
+      access.access = $event.value;
       this.backendService
         .createAccess(access)
         .subscribe({ next: response => (access.id = response.id) });
-    } else {
-      this.backendService.deleteAccess(access.id).subscribe();
     }
   }
 }

--- a/libs/damap/src/lib/domain/enum/function-role.enum.ts
+++ b/libs/damap/src/lib/domain/enum/function-role.enum.ts
@@ -1,7 +1,8 @@
 export enum FunctionRole {
-  ADMIN = 'ADMIN',
+  NO_RIGHTS = 'NO_RIGHTS', // frontend only for now
+  //ADMIN = 'ADMIN',
   EDITOR = 'EDITOR',
-  GUEST = 'GUEST',
+  //GUEST = 'GUEST',
   OWNER = 'OWNER',
-  SUPPORT = 'SUPPORT',
+  //SUPPORT = 'SUPPORT',
 }

--- a/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
+++ b/libs/damap/src/lib/widgets/dmp-table/dmp-table.component.html
@@ -109,7 +109,10 @@
           #menu="matMenu"
           xPosition="before"
           class="mat-menu-secondary-container">
-          <button mat-menu-item routerLink="/dmp/{{ element.id }}/access">
+          <button
+            mat-menu-item
+            *ngIf="element.accessType === FUNCTION_ROLES.OWNER || admin"
+            routerLink="/dmp/{{ element.id }}/access">
             <mat-icon>admin_panel_settings</mat-icon>
             {{ "plans.table.actions.access" | translate }}
           </button>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Feature

#### What does this PR do?

- Added radio buttons for assigning contributors rights to the DMP - now its also possible to assign ownership rights. Now only owners are allowed to assign and take away rights (previously editors could also give editor rights).
- Since the acess page is accessible to everyone that can fetch the DMP (bad design, should be changed in the future) contributors with editor rights could still see the access page over manipulating the URL. I prevented this by adding an alternative view with an info bar.
- Owners cant revoke their own ownership (circumvents the frontend validation for "there always has to eb at least one owner" and is just cheaper to do)
- To remove rights, i added the `NO_RIGHTS` role to the frontend. This change is *NOT* reflected in the backend, since the backend right now treats no rights as no access entity exists. This absolutely needs to be refactored, but this PR will not do it. Without the no rights role, its hard to use the radio buttons effectively.
- There is no warning when selectin owner, so users migth not know what this entails.

#### Code review focus

Security aspects. The surrounding code was not perfect and i refrained from a lot of otherwise necessary refactoring to save on time- this will be tackled on a later date.

#### Dependencies

[<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->](https://github.com/damap-org/damap-backend/pull/399)

closes GH-474
