### PR TITLE
Landing page: Hide "Start now" button and retry connection if backend is not running

### DIFF
--- a/apps/damap-frontend/src/app/components/landing-page/landing-page.component.html
+++ b/apps/damap-frontend/src/app/components/landing-page/landing-page.component.html
@@ -18,6 +18,7 @@
         </div>
         <div class="double-items fadeInLeft">
           <button
+            *ngIf="(backendDown$ | async) === false"
             mat-raised-button
             class="pulse-button button-color-primary"
             routerLink="/dashboard">

--- a/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
+++ b/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
@@ -4,6 +4,8 @@ import { RouterLink } from '@angular/router';
 import { MatAnchor, MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
 
 @Component({
   selector: 'app-landing-page',
@@ -20,10 +22,16 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
   standalone: true,
 })
 export class LandingPageComponent implements OnInit {
-  constructor(private translate: TranslateService) {}
+  public backendDown$: Observable<boolean>;
+
+  constructor(
+    private translate: TranslateService,
+    private configService: ConfigService,
+  ) {}
 
   ngOnInit(): void {
     const browserLang = this.translate.getBrowserLang();
     this.translate.use(browserLang?.match(/en|de/) ? browserLang : 'en');
+    this.backendDown$ = this.configService.isBackendDown();
   }
 }

--- a/apps/damap-frontend/src/assets/i18n/landing-page/de.json
+++ b/apps/damap-frontend/src/assets/i18n/landing-page/de.json
@@ -1,6 +1,9 @@
 {
   "landing-page": {
     "title": "DAMAP - ein Tool für machine-actionable DMPs",
-    "start": "Jetzt starten"
+    "start": "Jetzt starten",
+    "servers-down-retrying": "Verbindung zu unseren Servern konnte nicht hergestellt werden. Versuch wird wiederholt...",
+    "servers-down": "Unsere Server scheinen momentan nicht erreichbar zu sein. Versuchen Sie es bitte später noch einmal.",
+    "servers-up": "Verbindung zu unseren Servern wurde wiederhergestellt."
   }
 }

--- a/apps/damap-frontend/src/assets/i18n/landing-page/en.json
+++ b/apps/damap-frontend/src/assets/i18n/landing-page/en.json
@@ -1,6 +1,9 @@
 {
   "landing-page": {
     "title": "DAMAP - a tool for machine actionable DMPs",
-    "start": "Start now"
+    "start": "Start now",
+    "servers-down-retrying": "Failed to establish connection to our servers. Retrying...",
+    "servers-down": "Our servers seem to be down at the moment. Please try again later.",
+    "servers-up": "Connection to our servers has been re-established."
   }
 }

--- a/libs/damap/src/index.ts
+++ b/libs/damap/src/index.ts
@@ -29,6 +29,7 @@ export * from './lib/store/actions/internal-storage.actions';
 export * from './lib/guards/auth.guard';
 export * from './lib/auth/auth.service';
 export * from './lib/services/backend.service';
+export * from './lib/services/feedback.service';
 
 // Models
 export * from './lib/domain/access';

--- a/libs/damap/src/lib/services/feedback.service.ts
+++ b/libs/damap/src/lib/services/feedback.service.ts
@@ -13,10 +13,10 @@ export class FeedbackService {
     protected loggerService: LoggerService,
   ) {}
 
-  error(message: string, error?: Error) {
+  error(message: string, error?: Error, timeInMs: number = 4500) {
     this.translate.get(message).subscribe(translation =>
       this._snackBar.open(translation, 'x', {
-        duration: 4500,
+        duration: timeInMs,
         horizontalPosition: 'center',
         verticalPosition: 'top',
         panelClass: 'snack-error',


### PR DESCRIPTION
## Description

Feature

#### What does this PR do?

This PR hides the **Start now** button and introduces a retry mechanism for connecting to the servers.

Before: The **Start now** button would not work and not display an error message, were the backend to not be running.
Now: Hide the **Start now** button if the backend is not running, retry connection after 10 seconds.

#### Idea

Show initial message and hide **Start now** button:
<img width="2518" height="1624" alt="CleanShot 2025-08-05 at 11 33 40@2x" src="https://github.com/user-attachments/assets/584e6c9b-610f-48cf-9dd9-1069474a0e50" />

Show message again after 10 seconds and keep button hidden depending on second connection attempt.
Failure: 
<img width="2182" height="1796" alt="CleanShot 2025-08-05 at 11 33 52@2x" src="https://github.com/user-attachments/assets/ea243ab2-800b-4cdb-96c6-3afdd74c287b" />
or success:
<img width="2184" height="1680" alt="CleanShot 2025-08-05 at 11 36 57@2x" src="https://github.com/user-attachments/assets/cedd17ee-371b-4db6-b584-1be06f223264" />

#### Code review focus

Retry mechanism, feedback messages, added configService dependency to the landing page component.

closes GH-472
