### PR TITLE
How to create: Use updated TU links

### DIFF
--- a/libs/damap/src/assets/i18n/dashboard/en.json
+++ b/libs/damap/src/assets/i18n/dashboard/en.json
@@ -12,7 +12,7 @@
         "middle": " is a structured document that keeps record of what research data is created and what happens to that data during and after a project. It helps with planning the research process, managing your data in accordance with the ",
         "fairprinciples": {
           "text": "FAIR Principles",
-          "link": "https://www.tuwien.at/index.php?id=3307&L=1"
+          "link": "https://www.go-fair.org/fair-principles/"
         },
         "suffix": ", and defining rights and responsibilities in a research project involving several researchers or institutions."
       }

--- a/libs/damap/src/assets/i18n/dashboard/en.json
+++ b/libs/damap/src/assets/i18n/dashboard/en.json
@@ -7,12 +7,12 @@
         "prefix": "A ",
         "dmp": {
           "text": "DMP",
-          "link": "https://www.tuwien.at/en/research/rti-support/research-data/rdm-infos-tips/dmp"
+          "link": "https://www.tuwien.at/index.php?id=2819&L=1"
         },
         "middle": " is a structured document that keeps record of what research data is created and what happens to that data during and after a project. It helps with planning the research process, managing your data in accordance with the ",
         "fairprinciples": {
           "text": "FAIR Principles",
-          "link": "https://www.go-fair.org/fair-principles/"
+          "link": "https://www.tuwien.at/index.php?id=3307&L=1"
         },
         "suffix": ", and defining rights and responsibilities in a research project involving several researchers or institutions."
       }


### PR DESCRIPTION
## Description

Bugfix

#### What does this PR do?

This PR fixes the outdated links in the **instructions** component

Before: 
<img width="2472" height="1310" alt="CleanShot 2025-08-05 at 15 30 21@2x" src="https://github.com/user-attachments/assets/2d62e3e3-78cf-42de-aa16-d14ff69005d8" />

After:
<img width="2426" height="1478" alt="CleanShot 2025-08-05 at 15 29 26@2x" src="https://github.com/user-attachments/assets/8ce03690-a48c-4b40-b73e-ff4336fb8ff4" />


#### Code review focus

Any other links from the issue that are in DAMAP (and not  only TU DMP Tool) that need to be changed.

closes GH-480
