### PR TITLE
Step 2: improve UI

### DIFF
--- a/libs/damap/src/assets/i18n/templates/en.json
+++ b/libs/damap/src/assets/i18n/templates/en.json
@@ -40,7 +40,7 @@
         "intro": "In this step, you add people involved in the project and provide additional info about them, e.g., their role. In this example, the project leader’s info has already been added and marked as the contact person (note icon with person and envelope next to their name). You can add more contributors via the search field (ensure you select the appropriate database, e.g., ORCID), or manually via the “Add contributor manually button”. Please provide a minimum of one contact person as well as a data manager (it can be the same person).",
         "search": "Search for person...",
         "search.service": "Search service",
-        "general.search": "Find Contributors",
+        "general.search": "Find Contributors:",
         "general.recommendations": "Recommended contributors:",
         "general.addAll": "Add all contributors",
         "contributor": {

--- a/libs/damap/src/lib/components/dmp/people/contributor-manual/contributor-manual.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/contributor-manual/contributor-manual.component.ts
@@ -25,14 +25,17 @@ export class ContributorManualComponent {
     firstName: new UntypedFormControl('', [
       notEmptyValidator(),
       Validators.maxLength(4000),
+      Validators.required,
     ]),
     lastName: new UntypedFormControl('', [
       notEmptyValidator(),
       Validators.maxLength(4000),
+      Validators.required,
     ]),
     mbox: new UntypedFormControl('', [
       notEmptyValidator(),
       Validators.maxLength(4000),
+      Validators.required,
     ]),
     personId: new UntypedFormGroup({
       type: new UntypedFormControl(IdentifierType.ORCID),

--- a/libs/damap/src/lib/components/dmp/people/people.component.css
+++ b/libs/damap/src/lib/components/dmp/people/people.component.css
@@ -66,14 +66,10 @@ mat-form-field {
   gap: 15px;
 }
 
-.service-select-container {
-  flex: 1;
-  min-width: 175px;
-}
-
+.service-select-container,
 .app-person-search {
   flex: 1;
-  min-width: 200px;
+  min-width: 100px;
 }
 
 .form-fields {
@@ -131,11 +127,6 @@ mat-form-field {
     justify-content: space-between;
     margin-top: 10px;
   }
-
-  .search-and-service-container {
-    flex-direction: column;
-    gap: 20px;
-  }
 }
 
 .form-row {
@@ -163,11 +154,25 @@ mat-form-field {
   margin: 20px 5px;
 }
 
-@media (max-width: 1050px) {
+@media (max-width: 1100px) {
   mat-card {
     width: 100%;
   }
 
+  .search-and-service-container {
+    flex-direction: column;
+    gap: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .search-and-service-container {
+    flex-direction: row;
+    gap: 20px;
+  }
+}
+
+@media (max-width: 768px) {
   .search-and-service-container {
     flex-direction: column;
     gap: 0;

--- a/libs/damap/src/lib/components/dmp/people/people.component.css
+++ b/libs/damap/src/lib/components/dmp/people/people.component.css
@@ -66,10 +66,14 @@ mat-form-field {
   gap: 15px;
 }
 
-.service-select-container,
+.service-select-container {
+  flex: 1;
+  min-width: 175px;
+}
+
 .app-person-search {
   flex: 1;
-  min-width: 100px;
+  min-width: 200px;
 }
 
 .form-fields {
@@ -159,7 +163,7 @@ mat-form-field {
   margin: 20px 5px;
 }
 
-@media (max-width: 1300px) {
+@media (max-width: 1050px) {
   mat-card {
     width: 100%;
   }

--- a/libs/damap/src/lib/components/dmp/people/people.component.css
+++ b/libs/damap/src/lib/components/dmp/people/people.component.css
@@ -127,6 +127,11 @@ mat-form-field {
     justify-content: space-between;
     margin-top: 10px;
   }
+
+  .search-and-service-container {
+    flex-direction: column;
+    gap: 20px;
+  }
 }
 
 .form-row {
@@ -154,25 +159,11 @@ mat-form-field {
   margin: 20px 5px;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 1300px) {
   mat-card {
     width: 100%;
   }
 
-  .search-and-service-container {
-    flex-direction: column;
-    gap: 0;
-  }
-}
-
-@media (max-width: 900px) {
-  .search-and-service-container {
-    flex-direction: row;
-    gap: 20px;
-  }
-}
-
-@media (max-width: 768px) {
   .search-and-service-container {
     flex-direction: column;
     gap: 0;

--- a/libs/damap/src/lib/components/dmp/people/people.component.html
+++ b/libs/damap/src/lib/components/dmp/people/people.component.html
@@ -178,7 +178,7 @@
                   mat-icon-button
                   (click)="changeContactPerson()"
                   title="{{ 'dmp.steps.people.contact.remove' | translate }}">
-                  <mat-icon>person_remove</mat-icon>
+                  <mat-icon>stat_minus_2</mat-icon>
                 </button>
                 <button
                   mat-icon-button

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.html
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.html
@@ -1,5 +1,6 @@
 <form>
   <app-search-field
+    #contributorSearchField
     class="search-field"
     [label]="'dmp.steps.people.search'"
     (searchChange)="search($event)"></app-search-field>

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.ts
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.ts
@@ -40,6 +40,7 @@ export class PersonSearchComponent {
     if (person) {
       this.personToAdd.emit(person);
       this.searchField.control.setValue('');
+      this.currentSearchTerm = '';
     }
   }
 }

--- a/libs/damap/src/lib/widgets/person-search/person-search.component.ts
+++ b/libs/damap/src/lib/widgets/person-search/person-search.component.ts
@@ -1,7 +1,14 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
 
 import { Contributor } from '../../domain/contributor';
 import { MatSelectionListChange } from '@angular/material/list';
+import { SearchFieldComponent } from '../../shared/search-field/search-field.component';
 
 @Component({
   selector: 'app-person-search',
@@ -13,6 +20,8 @@ export class PersonSearchComponent {
   @Input() result: Contributor[] = [];
   @Output() termToSearch = new EventEmitter<string>();
   @Output() personToAdd = new EventEmitter<Contributor>();
+
+  @ViewChild('contributorSearchField') searchField!: SearchFieldComponent;
 
   currentSearchTerm: string = '';
 
@@ -30,6 +39,7 @@ export class PersonSearchComponent {
     let person = event.source.selectedOptions.selected[0]?.value;
     if (person) {
       this.personToAdd.emit(person);
+      this.searchField.control.setValue('');
     }
   }
 }


### PR DESCRIPTION
## Description

Feature

#### What does this PR do?

1. In People involved in data management step -> Search contributor -> Find Contributors:

- type in **Search for person...**
- select contributor 
- NEW: text is removed from search field

2. In People involved in data management step -> Search contributor -> Project contact:

- change icon from **person_remove** to **stat_minus_2**

3. In People involved in data management step -> Input contributor manually -> Additional contributors: 

- show a star (*) next to First name, Last name and email to show they are mandatory

#### Code review focus

1. For addition nr. 1, I think it would make sense to also close the autocomplete pane after selecting a contributor, not just removing the text in the search field.

2. (Not done) In People involved in data management step -> Input contributor manually -> Additional contributors: 

- as the screen in becoming smaller, have the 2 fields change to vertical alignment later
- this is very janky. By using media queries it either works for when the side-menu is open or when it is closed, but you cannot make it work for both situations.
- you either need an observable for the side-menu and apply conditional css, or another solution:
<img width="854" height="802" alt="CleanShot 2025-08-06 at 15 19 43@2x" src="https://github.com/user-attachments/assets/8cc30350-45c1-460c-9bcc-6396ed5146f0" />

- This works perfectly, independent of the side-menu state, as it uses the container size, not the screen size
- The problem with this is that @container media query is only supported for browser versions of the past 2-3 years.
- This is a diff that solves the problem, but from what I heard the side-menu is an overarching issue that may need an overhaul in the future. Tell me and I'll add this code to the PR.
[css.patch](https://github.com/user-attachments/files/21619734/css.patch)


closes GH-455
