### PR TITLE
How to Create: Add missing HE to text

### DIFF
--- a/libs/damap/src/assets/i18n/dashboard/en.json
+++ b/libs/damap/src/assets/i18n/dashboard/en.json
@@ -56,7 +56,7 @@
       },
       "export": {
         "heading": "Export the DMP draft as a document.",
-        "body": "Depending on the funder of your project, the exported DMP will either reflect the funder’s DMP template (FWF) or the DMP recommendations by Science Europe. This happens automatically for imported projects."
+        "body": "Depending on the funder of your project, the exported DMP will either reflect the funder’s DMP template (FWF, Horizon Europe) or the DMP recommendations by Science Europe. This happens automatically for imported projects."
       },
       "finalise": {
         "heading": "Finalise your DMP in a text editor.",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

Added Horizon Europe here as it was missing:
C:\Users\valyf\Work\DAMAP\damap-frontend\libs\damap\src\assets\i18n\dashboard\en.json

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-460
