### PR TITLE
Make project service nullsafe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ env.is-master-branch == 'true' || env.is-next-branch == 'true' }}
         run: npm run ci:test
 
-      - name: Publish Test Reportnpm run f
+      - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: always()
         with:

--- a/libs/damap/src/lib/components/dmp/dmp.component.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.component.ts
@@ -364,7 +364,7 @@ export class DmpComponent implements OnInit, OnDestroy {
 
   private getProjectMembers(projectId: number) {
     this.backendService.getProjectMembers(projectId).subscribe(members => {
-      this.projectMembers = members;
+      this.projectMembers = members ? members : [];
     });
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

When you are using the default project service and then switch to Pure, you get a null pointer. This PR fixes it.

This PR also fixes a small typo in the github workflow test.yml (thanks to Sotirios for spotting it immediately)