### PR TITLE
People: Fix wrong servicetype being used

### DIFF
--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -100,7 +100,7 @@ export class PeopleComponent implements OnInit, OnDestroy {
         .subscribe((term: string) => {
           this.searchResult$ = this.backendService.getPersonSearchResult(
             term,
-            this.serviceConfigType.displayText,
+            this.serviceConfigType.queryValue,
           );
         });
       this.subscriptions.push(searchSubscription);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Bugfix

#### What does this PR do?

Sends the correct queryvalue instead of the displaytext. This can cause bugs with the Pure integration and University service, since display is lowercase and query is all uppercase. To test it out move ORCID to first place in the person services. the frontend will now only use  the ORCID service (there is a fallback in the backend, which always chooses the first one when the service type is not found)
