### PR TITLE
Make translations work for the whole application

### DIFF
--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -1,3 +1,20 @@
+<div style="border: 2px solid red; padding: 20px; margin: 20px; background: #fff3cd;">
+  <h2>Translation Access Test - All Translation Files</h2>
+  <p><strong>From layout (app):</strong> {{ 'title' | translate }}</p>
+  <p><strong>From templates (libs):</strong> {{ 'dmp.steps.project.success' | translate }}</p>
+  <p><strong>From http (libs):</strong> {{ 'http.error.standard' | translate }}</p>
+  <p><strong>From plans (libs):</strong> {{ 'plans.mydmps' | translate }}</p>
+  <p><strong>From info (libs):</strong> <span [innerHTML]="'info.dataset.none' | translate"></span></p>
+  <p><strong>From help (libs):</strong> {{ 'help.legal.sensitiveDataSecurity' | translate }}</p>
+  <p><strong>From gdpr (libs):</strong> {{ 'gdpr.title' | translate }}</p>
+  <p><strong>From en.json base (libs):</strong> {{ 'yes' | translate }}</p>
+  <p><strong>From access (libs):</strong> {{ 'access.button.plans' | translate }}</p>
+  <p><strong>From landing-page (app):</strong> {{ 'landing-page.title' | translate }}</p>
+  <p><strong>From consent (app):</strong> {{ 'heading' | translate }}</p>
+  <p><strong>From admin (libs):</strong> {{ 'admin.title' | translate }}</p>
+  <p><strong>From dashboard (libs):</strong> {{ 'dashboard.welcome.message' | translate }}</p>
+</div>
+
 <app-info-card [infoLabel]="infoInstruction"></app-info-card>
 <div class="dmp-container">
   <div class="steps-container">

--- a/libs/damap/src/lib/components/dmp/dmp.module.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.module.ts
@@ -52,13 +52,6 @@ export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
     MatButtonToggleModule,
     TranslateModule.forChild({
       defaultLanguage: 'en',
-      loader: {
-        provide: TranslateLoader,
-        useFactory: HttpLoaderFactory,
-        deps: [HttpBackend],
-      },
-      isolate: true,
-      extend: true,
     }),
     VersionModule,
     AccessComponent,

--- a/libs/damap/src/lib/components/dmp/dmp.module.ts
+++ b/libs/damap/src/lib/components/dmp/dmp.module.ts
@@ -38,6 +38,9 @@ export function HttpLoaderFactory(http: HttpBackend): MultiTranslateHttpLoader {
     '/assets/damap-core/i18n/templates/',
     '/assets/damap-core/i18n/help/',
     '/assets/damap-core/i18n/info/',
+    '/assets/i18n/access/',
+    '/assets/i18n/help/',
+    '/assets/i18n/info/',
     '/assets/i18n/',
   ]);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

Enable usage of translation files for the DMP components by disabling the custom TranslateModule config and using the parent provided one from the top level module.

closes GH-499
