### PR TITLE
Costs: Fix small errors

### DIFF
--- a/libs/damap/src/lib/components/dmp/costs/costs.component.css
+++ b/libs/damap/src/lib/components/dmp/costs/costs.component.css
@@ -26,21 +26,16 @@ mat-radio-button {
   mat-panel-title {
     font-size: small;
   }
-
-  .cost-form-container {
-    margin-top: 15px;
-  }
 }
 
-.scrollable-cost-list button[mat-icon-button] {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  z-index: 1;
+.cost-form-container {
+  margin-top: 1rem;
+}
 
-  .scrollable-cost-list mat-expansion-panel {
-    margin-top: 20px;
-    position: relative;
-    padding-right: 40px;
-  }
+.remove-button {
+  margin-left: auto;
+  margin-right: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/libs/damap/src/lib/components/dmp/costs/costs.component.html
+++ b/libs/damap/src/lib/components/dmp/costs/costs.component.html
@@ -40,12 +40,6 @@
           <mat-expansion-panel
             class="expansion-panel"
             *ngFor="let item of list.controls; let i = index">
-            <button
-              mat-icon-button
-              aria-label="Remove cost"
-              (click)="removeCost(i)">
-              <mat-icon>cancel</mat-icon>
-            </button>
             <mat-expansion-panel-header>
               <mat-panel-title [class.form-error]="item.invalid">
                 {{ item.value.title }}
@@ -53,6 +47,13 @@
               <mat-panel-description>
                 {{ item.value.value | currency: item.value.currencyCode }}
               </mat-panel-description>
+              <button
+                mat-icon-button
+                class="remove-button"
+                aria-label="Remove cost"
+                (click)="removeCost(i)">
+                <mat-icon>cancel</mat-icon>
+              </button>
             </mat-expansion-panel-header>
             <div [formArrayName]="i" class="cost-form-container">
               <div class="form-row">

--- a/libs/damap/src/lib/components/dmp/dmp.component.html
+++ b/libs/damap/src/lib/components/dmp/dmp.component.html
@@ -340,10 +340,6 @@
           (costToAdd)="addCost()"
           (costToRemove)="removeCost($event)">
         </app-dmp-costs>
-
-        <div *ngIf="costsStep.invalid" class="error-message">
-          {{ "dmp.steps.costs.error" | translate }}
-        </div>
       </ng-container>
     </ng-container>
     <ng-container *ngIf="selectedStep === 10">

--- a/libs/damap/src/lib/services/form.service.ts
+++ b/libs/damap/src/lib/services/form.service.ts
@@ -714,7 +714,7 @@ export class FormService {
   private createCostFormGroup(): UntypedFormGroup {
     return this.formBuilder.group({
       id: new FormControl<number>({ value: null, disabled: true }),
-      title: new FormControl<string>('New cost', {
+      title: new FormControl<string>('Cost Name', {
         validators: [
           Validators.required,
           Validators.maxLength(this.TEXT_SHORT_LENGTH),

--- a/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.html
+++ b/libs/damap/src/lib/shared/input-wrapper/input-wrapper.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [appearance]="appearance">
+<mat-form-field [appearance]="appearance" subscriptSizing="dynamic">
   <mat-label>
     {{ label | translate }}
     <app-tooltip *ngIf="info?.length" [tooltip]="info"></app-tooltip>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
The changes concern step 10, costs.
1. Changed the location of the X button of the costs items so that it does not overlap with the expand arrow.
2. Changed default name 'New Cost' to 'Cost Name'.
3. Made format error text shorter so it does not get cut off.
4. Removed `dmp.steps.costs.error` since it does not resolve to any error text. The error text below the cost input field already covers this.
<!-- Changes introduced by this PR - what happened before, what happens now -->


closes GH-458<!-- insert issue number -->
