### PR TITLE
Fix: Cache recommended projects and add error handling

### DIFF
--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.html
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.html
@@ -9,30 +9,35 @@
     [label]="'dmp.steps.project.search' | translate"
     (searchChange)="search($event)"></app-search-field>
   <div class="list-container" *ngIf="!selectedProject">
-    <mat-selection-list
-      hideSingleSelectionIndicator
-      [multiple]="false"
-      style="overflow: hidden"
-      (selectionChange)="changeProject($event)">
-      <mat-list-option
-        *ngFor="let project of (searchResult$ | async)?.items ?? []"
-        [style]="'height: auto;'"
-        [selected]="project.universityId === selectedProject?.universityId"
-        [value]="project">
-        <div matListItemTitle>
-          <strong>{{ project.title }}</strong>
-        </div>
-        <div matListItemLine>
-          <mat-icon class="mat-icon-style">date_range</mat-icon>
-          {{ project.start | date }} - {{ project.end | date }}
-          <mat-icon
-            *ngIf="project.dmpExists"
-            matTooltip="{{ 'dmp.steps.project.warning.dmp' | translate }}"
-            class="material-icon-warning mat-list-option-right">
-            warning
-          </mat-icon>
-        </div>
-      </mat-list-option>
-    </mat-selection-list>
+    <ng-container *ngIf="loading$ | async; else listTpl">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </ng-container>
+    <ng-template #listTpl>
+      <mat-selection-list
+        hideSingleSelectionIndicator
+        [multiple]="false"
+        style="overflow: hidden"
+        (selectionChange)="changeProject($event)">
+        <mat-list-option
+          *ngFor="let project of (searchResult$ | async)?.items ?? []"
+          [style]="'height: auto;'"
+          [selected]="project.universityId === selectedProject?.universityId"
+          [value]="project">
+          <div matListItemTitle>
+            <strong>{{ project.title }}</strong>
+          </div>
+          <div matListItemLine>
+            <mat-icon class="mat-icon-style">date_range</mat-icon>
+            {{ project.start | date }} - {{ project.end | date }}
+            <mat-icon
+              *ngIf="project.dmpExists"
+              matTooltip="{{ 'dmp.steps.project.warning.dmp' | translate }}"
+              class="material-icon-warning mat-list-option-right">
+              warning
+            </mat-icon>
+          </div>
+        </mat-list-option>
+      </mat-selection-list>
+    </ng-template>
   </div>
 </ng-container>

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
@@ -1,19 +1,25 @@
 import {
-  AfterViewInit,
+  BehaviorSubject,
+  Observable,
+  Subject,
+  Subscription,
+  catchError,
+  debounceTime,
+  distinctUntilChanged,
+  finalize,
+  merge,
+  of,
+  shareReplay,
+  switchMap,
+} from 'rxjs';
+import {
   Component,
   EventEmitter,
   Input,
+  OnDestroy,
   OnInit,
   Output,
 } from '@angular/core';
-import {
-  Observable,
-  Subject,
-  debounceTime,
-  distinctUntilChanged,
-  of,
-  switchMap,
-} from 'rxjs';
 
 import { BackendService } from '../../../../services/backend.service';
 import { MatDialog } from '@angular/material/dialog';
@@ -27,7 +33,7 @@ import { SearchResult } from '../../../../domain/search/search-result';
   styleUrls: ['./project-list.component.css'],
   standalone: false,
 })
-export class ProjectListComponent implements OnInit, AfterViewInit {
+export class ProjectListComponent implements OnInit, OnDestroy {
   @Output() projectToSet = new EventEmitter<Project>();
   private _selectedProject: Project;
 
@@ -44,35 +50,73 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
   }
 
   private searchTerms = new Subject<string>();
-  searchResult$: Observable<SearchResult<Project>>;
+  private recommendedProjects$: Observable<SearchResult<Project>>;
+  private loadingSubject = new BehaviorSubject<boolean>(true);
+  private searchResultSubscription: Subscription;
+  loading$: Observable<boolean> = this.loadingSubject.asObservable();
+  searchResult$: Observable<SearchResult<Project>> = of({
+    items: [],
+  } as SearchResult<Project>);
 
   constructor(
     private backendService: BackendService,
     public dialog: MatDialog,
-  ) {}
-
-  ngOnInit(): void {
-    this.searchTerms
+  ) {
+    this.recommendedProjects$ = this.backendService
+      .getRecommendedProjects()
       .pipe(
-        debounceTime(300),
-        distinctUntilChanged((previous, current) => {
-          if (previous === null && current === null) {
-            // search for recommended projects
-            return false;
-          }
-          return previous === current;
+        catchError(error => {
+          console.error('Error fetching recommended projects:', error);
+          return of({ items: [] } as SearchResult<Project>);
         }),
-        switchMap((term: string) =>
-          term === null || term.length === 0
-            ? this.backendService.getRecommendedProjects()
-            : this.backendService.getProjectSearchResult(term),
-        ),
-      )
-      .subscribe(results => (this.searchResult$ = of(results)));
+        shareReplay(1),
+      );
   }
 
-  ngAfterViewInit(): void {
-    this.fetchRecommendedProjects();
+  ngOnInit(): void {
+    const debouncedSearchTerms$ = this.searchTerms.pipe(debounceTime(300));
+
+    this.searchResult$ = merge(of(null), debouncedSearchTerms$).pipe(
+      distinctUntilChanged((previous, current) => {
+        const prevIsEmpty =
+          previous === null || previous === undefined || previous === '';
+        const currIsEmpty =
+          current === null || current === undefined || current === '';
+        if (prevIsEmpty && currIsEmpty) {
+          return true;
+        }
+        return previous === current;
+      }),
+      switchMap((term: string) => {
+        this.loadingSubject.next(true);
+        const normalizedTerm =
+          term === null ||
+          term === undefined ||
+          (typeof term === 'string' && term.trim().length === 0)
+            ? null
+            : term;
+
+        if (normalizedTerm === null) {
+          return this.recommendedProjects$.pipe(
+            finalize(() => this.loadingSubject.next(false)),
+          );
+        }
+        return this.backendService.getProjectSearchResult(normalizedTerm).pipe(
+          catchError(error => {
+            console.error('Error searching projects:', error);
+            return of({ items: [] } as SearchResult<Project>);
+          }),
+          finalize(() => this.loadingSubject.next(false)),
+        );
+      }),
+      shareReplay(1),
+    );
+
+    this.searchResultSubscription = this.searchResult$.subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.searchResultSubscription?.unsubscribe();
   }
 
   fetchRecommendedProjects(): void {

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
@@ -69,7 +69,6 @@ export class ProjectListComponent implements OnInit, OnDestroy {
           console.error('Error fetching recommended projects:', error);
           return of({ items: [] } as SearchResult<Project>);
         }),
-        shareReplay(1),
       );
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

The project list stayed in loading because searchResult$ was only subscribed to when the list was visible - when loading was already false. The stream is now subscribed in the component and searchResult$ uses shareReplay(1) so the request runs on init and the template still gets the result. Loading is cleared in ngOnDestroy.

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
