### PR TITLE
Patch GitHub security warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  continuous-integration:
+  ci:
+    name: continuous-integration
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  continuous-integration:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: test
 
+permissions:
+  contents: read
+  checks: write
+
 env:
   is-master-branch: ${{ github.ref == 'refs/heads/master' }}
   is-next-branch: ${{ github.ref == 'refs/heads/next' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,6 @@ ARG APP=damap-frontend
 
 # create a second container running a webserver and holding the built frontend application
 FROM nginxinc/nginx-unprivileged AS runner
-ADD docker/conf.d/* /etc/nginx/conf.d
+COPY docker/conf.d/* /etc/nginx/conf.d
 
 COPY --from=deps --chown=1001:0 /app/dist/damap-frontend/ /usr/share/nginx/html/


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Small security patches
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
Fix the following CodeQL and SonarCloud security warnings:
- Replace `ADD` in the Dockerfile with `COPY`. `ADD` is essentially `COPY` but with 2 extras: fetch-from-URL functionality and automatic TAR file extraction. These 2 extras are not needed here since we only copy a configuration file from the build context.
- Specified (and narrowed) `GITHUB_TOKEN` permissions for the continuous integration workflow. The job name was also changed from `build` to `continuous-integration` to be less confusing.


closes GH-<!-- insert issue number -->
