### PR TITLE
Replace FITS service

### DIFF
--- a/apps/damap-frontend-e2e/src/e2e/dmp.cy.ts
+++ b/apps/damap-frontend-e2e/src/e2e/dmp.cy.ts
@@ -11,7 +11,7 @@ describe('dmp', () => {
 
   it('should create and autosave dmp', () => {
     cy.intercept('PUT', '/api/dmps/*').as('updateDmp');
-    cy.intercept('POST', '/api/fits/examine').as('examineFile');
+    cy.intercept('POST', '/api/file-analysis/examine').as('examineFile');
     // Create new dmp
     cy.get('div.button-row-left > button').last().click();
     // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/apps/damap-frontend/src/app/services/config.service.spec.ts
+++ b/apps/damap-frontend/src/app/services/config.service.spec.ts
@@ -37,7 +37,6 @@ describe('ConfigService', () => {
     appTitle: 'Test App Title',
     personSearchServiceConfigs: [],
     projectSearchServiceConfig: null,
-    fitsServiceAvailable: false,
     livePreviewAvailable: true,
     ethicalReportEnabled: true,
     multitenancyEnabled: false,
@@ -142,7 +141,6 @@ describe('ConfigService', () => {
         env: 'test-env',
         appTitle: null,
         personSearchServiceConfigs: [],
-        fitsServiceAvailable: false,
         livePreviewAvailable: true,
       };
 

--- a/apps/damap-frontend/src/assets/i18n/translations.json
+++ b/apps/damap-frontend/src/assets/i18n/translations.json
@@ -601,8 +601,6 @@
     "http.error.errorCodes.ORCID_PERSON_NOT_FOUND": "A person you searched for with ORCID couldn't be found.",
     "http.error.errorCodes.ORCID_NOT_AVAILABLE": "The ORCID person service is currently unavailable. Please try again later.",
     "http.error.errorCodes.ORCID_UNEXPECTED_ERROR": "The ORCID person service is currently unavailable due to an unexpected error. Please try again later.",
-    "http.error.errorCodes.FITS_NOT_AVAILABLE": "The file analysis service is currently unavailable. Please try again later.",
-    "http.error.errorCodes.FITS_UNEXPECTED_ERROR": "The file analysis service is currently unavailable due to an unexpected error. Please try again later.",
     "http.error.errorCodes.OPENAIRE_NOT_FOUND": "A dataset you searched for couldn't be found.",
     "http.error.errorCodes.OPENAIRE_NOT_AVAILABLE": "The OpenAire dataset service is currently unavailable. Please try again later.",
     "http.error.errorCodes.OPENAIRE_UNEXPECTED_ERROR": "The OpenAire dataset service is currently unavailable due to an unexpected error. Please try again later.",

--- a/libs/damap/src/assets/i18n/http/en.json
+++ b/libs/damap/src/assets/i18n/http/en.json
@@ -11,8 +11,6 @@
         "ORCID_PERSON_NOT_FOUND": "A person you searched for with ORCID couldn't be found.",
         "ORCID_NOT_AVAILABLE": "The ORCID person service is currently unavailable. Please try again later.",
         "ORCID_UNEXPECTED_ERROR": "The ORCID person service is currently unavailable due to an unexpected error. Please try again later.",
-        "FITS_NOT_AVAILABLE": "The file analysis service is currently unavailable. Please try again later.",
-        "FITS_UNEXPECTED_ERROR": "The file analysis service is currently unavailable due to an unexpected error. Please try again later.",
         "OPENAIRE_NOT_FOUND": "A dataset you searched for couldn't be found.",
         "OPENAIRE_NOT_AVAILABLE": "The OpenAire dataset service is currently unavailable. Please try again later.",
         "OPENAIRE_UNEXPECTED_ERROR": "The OpenAire dataset service is currently unavailable due to an unexpected error. Please try again later.",

--- a/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.html
@@ -9,7 +9,7 @@
             {{ "dmp.steps.data.specify.button.add.manual" | translate }}
           </button>
         </div>
-        <div class="example-button-container" *ngIf="fitsServiceAvailable">
+        <div class="example-button-container">
           <button mat-flat-button (click)="openUploadDialog()">
             <mat-icon>cloud_upload</mat-icon>
             {{ "dmp.steps.data.specify.tab.upload" | translate }}

--- a/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.spec.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.spec.ts
@@ -40,31 +40,6 @@ describe('CreatedDataComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('ngOnInit', () => {
-    it('should load service config and set FITS service availability flag', () => {
-      component.ngOnInit();
-      expect(component.fitsServiceAvailable).toEqual(
-        configMockData.fitsServiceAvailable,
-      );
-    });
-  });
-
-  it('file upload not available if no FITS service available', () => {
-    component.fitsServiceAvailable = false;
-    const element = fixture.debugElement.query(
-      By.directive(FileUploadComponent),
-    );
-    expect(element).toBeNull();
-  });
-
-  it('file upload available if FITS service available', () => {
-    component.fitsServiceAvailable = true;
-    const element = fixture.debugElement.query(
-      By.directive(FileUploadComponent),
-    );
-    expect(element).toBeDefined();
-  });
-
   it('should emit file to analyse', () => {
     spyOn(component.fileToAnalyse, 'emit');
     const file = new File([], 'test.txt');

--- a/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/created-data/created-data.component.ts
@@ -1,12 +1,5 @@
-import { BehaviorSubject, Observable, Subscription } from 'rxjs';
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Observable } from 'rxjs';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { AbstractBaseDataComponent } from '../abstract-base-data.component';
 import { Config } from '../../../../domain/config';
@@ -21,20 +14,12 @@ import { UntypedFormControl } from '@angular/forms';
   styleUrls: ['./created-data.component.css'],
   standalone: false,
 })
-export class CreatedDataComponent
-  extends AbstractBaseDataComponent
-  implements OnInit, OnDestroy
-{
+export class CreatedDataComponent extends AbstractBaseDataComponent {
   @Input() fileUpload: { file: File; progress: number; finalized: boolean }[];
   @Input() config$: Observable<Config>;
 
   @Output() fileToAnalyse = new EventEmitter<File>();
   @Output() uploadToCancel = new EventEmitter<number>();
-  @Input() fitsServiceAvailable$: BehaviorSubject<boolean>;
-  fitsServiceAvailable: boolean;
-  fitsServiceSubscription: Subscription;
-
-  configSubscription: Subscription;
 
   readonly tableHeaders: string[] = [
     'dataset',
@@ -47,20 +32,6 @@ export class CreatedDataComponent
 
   constructor(public dialog: MatDialog) {
     super();
-  }
-
-  ngOnInit(): void {
-    if (this.fitsServiceAvailable$) {
-      this.fitsServiceSubscription = this.fitsServiceAvailable$.subscribe(
-        value => {
-          this.fitsServiceAvailable = value;
-        },
-      );
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.fitsServiceSubscription?.unsubscribe();
   }
 
   openDatasetDialog() {

--- a/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.html
+++ b/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.html
@@ -2,7 +2,6 @@
   <div *ngIf="selectedView === 'primaryView'">
     <app-created-data
       *ngIf="selectedView === 'primaryView'"
-      [fitsServiceAvailable$]="fitsServiceAvailable$"
       [specifyDataStep]="specifyDataStep"
       [datasets]="datasets"
       [fileUpload]="fileUpload"

--- a/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.ts
+++ b/libs/damap/src/lib/components/dmp/specify-data/specify-data.component.ts
@@ -1,12 +1,5 @@
-import { BehaviorSubject, Observable, Subscription } from 'rxjs';
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Observable } from 'rxjs';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { AbstractBaseDataComponent } from './abstract-base-data.component';
 import { Config } from '../../../domain/config';
@@ -18,35 +11,14 @@ import { UntypedFormControl } from '@angular/forms';
   styleUrls: ['./specify-data.component.css'],
   standalone: false,
 })
-export class SpecifyDataComponent
-  extends AbstractBaseDataComponent
-  implements OnInit, OnDestroy
-{
+export class SpecifyDataComponent extends AbstractBaseDataComponent {
   @Input() fileUpload: { file: File; progress: number; finalized: boolean }[];
   @Input() config$: Observable<Config>;
 
   @Output() fileToAnalyse = new EventEmitter<File>();
   @Output() uploadToCancel = new EventEmitter<number>();
 
-  fitsServiceAvailable$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   selectedView: 'primaryView' | 'secondaryView' = 'primaryView';
-
-  private configSubscription: Subscription;
-
-  ngOnInit(): void {
-    if (this.config$) {
-      this.config$.subscribe(config => {
-        this.fitsServiceAvailable$.next(!!config.fitsServiceAvailable);
-        //console.log('fitsServiceAvailable updated in SpecifyDataComponent:', !!config.fitsServiceAvailable);
-      });
-    }
-  }
-
-  ngOnDestroy(): void {
-    if (this.configSubscription) {
-      this.configSubscription.unsubscribe();
-    }
-  }
 
   get dataGeneration(): UntypedFormControl {
     return this.specifyDataStep.get('dataGeneration') as UntypedFormControl;

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -18,7 +18,6 @@ export interface Config {
   readonly appTitle: string;
   readonly personSearchServiceConfigs: ServiceConfig[];
   readonly projectSearchServiceConfig: string;
-  readonly fitsServiceAvailable: boolean;
   readonly livePreviewAvailable: boolean;
   readonly ethicalReportEnabled: boolean;
   readonly images: BackendImage[];

--- a/libs/damap/src/lib/mocks/config-service-mocks.ts
+++ b/libs/damap/src/lib/mocks/config-service-mocks.ts
@@ -16,7 +16,6 @@ export const configMockData: Config = {
   env: '',
   appTitle: '',
   personSearchServiceConfigs: serviceConfigMockData,
-  fitsServiceAvailable: true,
   livePreviewAvailable: true,
   ethicalReportEnabled: true,
 };

--- a/libs/damap/src/lib/services/backend.service.spec.ts
+++ b/libs/damap/src/lib/services/backend.service.spec.ts
@@ -210,7 +210,9 @@ describe('BackendService', () => {
       }
     });
 
-    const req = httpTestingController.expectOne(`${backendUrl}fits/examine`);
+    const req = httpTestingController.expectOne(
+      `${backendUrl}file-analysis/examine`,
+    );
     expect(req.request.method).toEqual('POST');
     req.event({ type: HttpEventType.UploadProgress, loaded: 7, total: 10 });
     req.event({

--- a/libs/damap/src/lib/services/backend.service.ts
+++ b/libs/damap/src/lib/services/backend.service.ts
@@ -281,7 +281,7 @@ export class BackendService {
 
   analyseFileData(file: FormData): Observable<HttpEvent<any>> {
     return this.http
-      .post(`${this.backendUrl}fits/examine`, file, {
+      .post(`${this.backendUrl}file-analysis/examine`, file, {
         reportProgress: true,
         observe: 'events',
       })

--- a/libs/damap/src/lib/widgets/file-upload/file-upload.component.html
+++ b/libs/damap/src/lib/widgets/file-upload/file-upload.component.html
@@ -15,7 +15,7 @@
     mat-flat-button
     class="upload-btn button-position"
     (click)="fileDrop.click()">
-    <label for="fileDrop">{{ "upload.file.choose" | translate }}</label>
+    <span>{{ "upload.file.choose" | translate }}</span>
     <mat-icon>attach_file</mat-icon>
   </button>
 </div>

--- a/libs/damap/src/lib/widgets/file-upload/file-upload.component.ts
+++ b/libs/damap/src/lib/widgets/file-upload/file-upload.component.ts
@@ -19,7 +19,10 @@ export class FileUploadComponent {
   }
 
   onFileSelected(event) {
-    this.onFileDropped(event.target.files);
+    if (event.target.files && event.target.files.length > 0) {
+      this.onFileDropped(event.target.files);
+      event.target.value = '';
+    }
   }
 
   cancelUpload(index: number) {


### PR DESCRIPTION

## Description

<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Refactoring
#### What does this PR do?
This PR accompanies the backend PR that replaces the FITS service with a lightweight Java library (Apache Tika). 

Frontend changes:
- Renamed the api endpoint that analyzes the MIME type of an uploaded file: from `/api/fits/examine` to `/api/file-analysis/examine`.
- Removed the `fitsServiceAvailable` boolean from the config, since the file analysis is always available when the backend is.
- Removed some unused imports and variables.
- Updated E2E tests.
<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Dependencies
Backend PR: https://github.com/damap-org/damap-backend/pull/477
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->
