### PR TITLE
Multitenancy: Make landing page multitenancy safe

### DIFF
--- a/apps/damap-frontend/src/app/services/color-theme.service.ts
+++ b/apps/damap-frontend/src/app/services/color-theme.service.ts
@@ -69,9 +69,11 @@ export class ColorThemeService {
   private applyMaterial3Tokens(colors: Colors, exactMode: boolean): void {
     // 1. Generate Base Palette & Scheme
     const palette = CorePalette.fromColors({
-      primary: argbFromHex(colors.primary || '#6200ee'),
+      primary: argbFromHex(colors.primary || '#006699'),
       secondary: colors.secondary ? argbFromHex(colors.secondary) : undefined,
-      tertiary: colors.tertiary ? argbFromHex(colors.tertiary) : undefined,
+      tertiary: colors.tertiary
+        ? argbFromHex(colors.tertiary || '#373737')
+        : undefined,
     });
     const scheme = Scheme.lightFromCorePalette(palette);
 

--- a/libs/damap/src/lib/components/admin/edit-images-page/edit-images-page.component.css
+++ b/libs/damap/src/lib/components/admin/edit-images-page/edit-images-page.component.css
@@ -42,15 +42,9 @@
 
 .current-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(18vw, 1fr));
   gap: 10px;
   padding: 0 8px 8px 8px;
-}
-
-.current-grid .centered {
-  grid-column: 1 / span 3;
-  margin: 0 auto;
-  justify-self: center;
 }
 
 .flex-card {

--- a/libs/damap/src/lib/components/admin/edit-images-page/edit-images-page.component.html
+++ b/libs/damap/src/lib/components/admin/edit-images-page/edit-images-page.component.html
@@ -17,16 +17,8 @@
           </mat-card-title>
         </mat-card-header>
         <div class="current-grid">
-          @for (
-            image of themeImages();
-            track image.key;
-            let isLast = $last;
-            let isEven = $even
-          ) {
-            <mat-card
-              class="image-card"
-              [class.centered]="isLast && isEven"
-              (click)="selectImageKey(image.key)">
+          @for (image of themeImages(); track image.key) {
+            <mat-card class="image-card" (click)="selectImageKey(image.key)">
               <div class="image-name">
                 {{ image.label }}
               </div>

--- a/libs/damap/src/lib/components/admin/edit-images-page/edit-images-page.component.ts
+++ b/libs/damap/src/lib/components/admin/edit-images-page/edit-images-page.component.ts
@@ -24,7 +24,6 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Router } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { environment } from '../../../../../../../apps/damap-frontend/src/environments/environment';
 import { ConfigService } from '../../../../../../../apps/damap-frontend/src/app/services/config.service';
 import {
   ImageKey,
@@ -74,7 +73,9 @@ export class EditImagesPageComponent {
     const config = this.configService.getConfig();
     const backendImages = config?.images || [];
 
-    return THEME_IMAGE_DEFINITIONS.map(imageDef => {
+    return THEME_IMAGE_DEFINITIONS.filter(
+      imageDef => !(imageDef.multitenancyLocked && config.multitenancyEnabled),
+    ).map(imageDef => {
       const backendImg = backendImages.find(
         beImg => beImg.imageKey === imageDef.key,
       );
@@ -90,7 +91,7 @@ export class EditImagesPageComponent {
   });
 
   readonly selectedFile = signal<File | null>(null);
-  readonly selectedImageKey = signal(THEME_IMAGE_DEFINITIONS[0].key);
+  readonly selectedImageKey = signal(this.themeImages()[0].key);
   readonly isDragOver = signal(false);
   readonly acceptAttribute = getAcceptAttribute();
 
@@ -135,7 +136,7 @@ export class EditImagesPageComponent {
       .subscribe({
         next: () => {
           this.feedbackService.success('admin.images.upload.success');
-          this.selectedImageKey.set(THEME_IMAGE_DEFINITIONS[0].key);
+          this.selectedImageKey.set(this.themeImages()[0].key);
           window.location.reload();
         },
         error: error => {

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -22,5 +22,5 @@ export interface Config {
   readonly ethicalReportEnabled: boolean;
   readonly images: BackendImage[];
   readonly colorTheme: ColorTheme;
-  readonly institutionMode?: boolean;
+  readonly multitenancyEnabled: boolean;
 }

--- a/libs/damap/src/lib/domain/image-keys.ts
+++ b/libs/damap/src/lib/domain/image-keys.ts
@@ -45,6 +45,7 @@ export interface ThemeImageDefinition {
   defaultUrl: string;
   recommendation: string;
   isCustom?: boolean;
+  multitenancyLocked?: boolean;
 }
 
 export const THEME_IMAGE_DEFINITIONS: ThemeImageDefinition[] = [
@@ -53,18 +54,21 @@ export const THEME_IMAGE_DEFINITIONS: ThemeImageDefinition[] = [
     label: 'Landing Page Background',
     defaultUrl: 'assets/landing-page-background.png',
     recommendation: 'Recommended size: 1200px x 700px',
+    multitenancyLocked: true,
   },
   {
     key: IMAGE_KEYS.LANDING_PAGE_GRAPHIC,
     label: 'Landing Page Graphic',
     defaultUrl: 'assets/landing-page-graphic.png',
     recommendation: 'Recommended size: 2530px x 2159px',
+    multitenancyLocked: true,
   },
   {
     key: IMAGE_KEYS.LANDING_PAGE_LOGO,
     label: 'Landing Page Logo',
     defaultUrl: 'assets/landing-page-logo.svg',
     recommendation: 'Scales proportionally up to aspect ratio: 2.67:1',
+    multitenancyLocked: true,
   },
   {
     key: IMAGE_KEYS.LOGO,
@@ -72,17 +76,20 @@ export const THEME_IMAGE_DEFINITIONS: ThemeImageDefinition[] = [
     defaultUrl: 'assets/logo.svg',
     recommendation:
       'Recommended aspect ratio: Around 1.41:1 (A4 paper landscape)',
+    multitenancyLocked: false,
   },
   {
     key: IMAGE_KEYS.ORCID_ID,
     label: 'ORCID ID',
     defaultUrl: 'assets/ORCIDiD_iconvector.svg',
     recommendation: 'Recommended aspect ratio: 1:1',
+    multitenancyLocked: false,
   },
   {
     key: IMAGE_KEYS.FAVICON,
     label: 'Favicon',
     defaultUrl: 'favicon.ico',
     recommendation: 'Recommended aspect ratio: 1:1',
+    multitenancyLocked: false,
   },
 ];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

Made basecolor the normal blue DAMAP used before - this way, the landing page looks like it has until now in multitenancy mode. I also made the landing page images not configurable in multitenancy mode by adding a locked variable and using the backend multitenancy config variable.  This way, admins dont get the wrong idea that they are able to change the landing page.

closes GH-520
