### PR TITLE
Vd/fix config loading on multitenancy

### DIFF
--- a/apps/damap-frontend/src/app/services/config.service.spec.ts
+++ b/apps/damap-frontend/src/app/services/config.service.spec.ts
@@ -36,9 +36,12 @@ describe('ConfigService', () => {
     env: 'test-env',
     appTitle: 'Test App Title',
     personSearchServiceConfigs: [],
+    projectSearchServiceConfig: null,
     fitsServiceAvailable: false,
     livePreviewAvailable: true,
     ethicalReportEnabled: true,
+    multitenancyEnabled: false,
+    templates: [],
     images: [
       {
         id: 1,
@@ -110,6 +113,11 @@ describe('ConfigService', () => {
       expect(req.request.method).toBe('GET');
       req.flush(mockConfig);
 
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const req2 = httpMock.expectOne(`${environment.backendurl}config`);
+      req2.flush(mockConfig);
+
       await initializePromise;
 
       expect(mockOAuthService.configure).toHaveBeenCalledWith({
@@ -147,6 +155,11 @@ describe('ConfigService', () => {
       const initializePromise = service.initializeApp();
       const req = httpMock.expectOne(`${environment.backendurl}config`);
       req.flush(mockConfig);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const req2 = httpMock.expectOne(`${environment.backendurl}config`);
+      req2.flush(mockConfig);
 
       await initializePromise;
       // eslint-disable-next-line no-console

--- a/apps/damap-frontend/src/app/services/config.service.ts
+++ b/apps/damap-frontend/src/app/services/config.service.ts
@@ -70,11 +70,16 @@ export class ConfigService {
           this.oauthService.setupAutomaticSilentRefresh();
           return this.oauthService
             .loadDiscoveryDocumentAndTryLogin()
-            .then(() => {
+            .then(async () => {
               if (
                 this.oauthService.hasValidIdToken() &&
                 this.oauthService.hasValidAccessToken()
               ) {
+                const tenantConfig = await this.loadConfig();
+                this.config = tenantConfig;
+                this.colorThemeService.applyTheming(tenantConfig);
+                this.imageThemeService.applyTheming(tenantConfig);
+
                 const url = decodeURIComponent(this.oauthService.state!);
                 if (url !== '') {
                   return this.router.navigateByUrl(url);

--- a/apps/damap-frontend/src/app/services/config.service.ts
+++ b/apps/damap-frontend/src/app/services/config.service.ts
@@ -89,7 +89,8 @@ export class ConfigService {
                 }
               }
               return true;
-            }).catch(error => {
+            })
+            .catch(error => {
               // TODO: Use the same error handling mechanism as the main config call
               /* eslint-disable no-console */
               console.error(

--- a/apps/damap-frontend/src/app/services/config.service.ts
+++ b/apps/damap-frontend/src/app/services/config.service.ts
@@ -62,9 +62,7 @@ export class ConfigService {
             responseType: config.responseType,
             oidc: true,
             scope: config.scope,
-            // useSilentRefresh: true,
             showDebugInformation: isDevMode(),
-            // sessionChecksEnabled: true,
           };
           this.oauthService.configure(authConfig);
           this.oauthService.setupAutomaticSilentRefresh();
@@ -79,13 +77,26 @@ export class ConfigService {
                 this.config = tenantConfig;
                 this.colorThemeService.applyTheming(tenantConfig);
                 this.imageThemeService.applyTheming(tenantConfig);
+                const appTitle = config.appTitle;
+                if (!appTitle) {
+                  // eslint-disable-next-line no-console
+                  console.warn('App title is missing in the config');
+                }
 
                 const url = decodeURIComponent(this.oauthService.state!);
                 if (url !== '') {
                   return this.router.navigateByUrl(url);
                 }
               }
-              return new Promise<boolean>(resolve => resolve(true));
+              return true;
+            }).catch(error => {
+              // TODO: Use the same error handling mechanism as the main config call
+              /* eslint-disable no-console */
+              console.error(
+                'Failed to load tenant specific config after login - please make sure your backend is up and running!',
+              );
+              console.error(error);
+              return false;
             });
         }
       })
@@ -110,7 +121,7 @@ export class ConfigService {
           this.feedbackService.error('landing-page.servers-down', undefined, 0);
         }
 
-        return new Promise<boolean>(resolve => resolve(false));
+        return false;
       });
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

Fixes an issue in multitenancy mode where configs are loaded before user logs in - making it impossible to load tenant specific configs. The solution employed in this PR uses the most anive solution of just reloading configs after the user has logged in, replacing the defaults with tenant specific configurations like images or urls.


closes GH-518
