### PR TITLE
Remove default banner flickering on startup

### DIFF
--- a/libs/damap/src/lib/widgets/app-banner/app-banner.component.ts
+++ b/libs/damap/src/lib/widgets/app-banner/app-banner.component.ts
@@ -11,14 +11,9 @@ import { BackendService } from '../../services/backend.service';
 export class AppBannerComponent implements OnInit {
   constructor(private backendService: BackendService) {}
 
-  banner: Banner = {
-    title: 'Default Title',
-    description: 'Default Description',
-    dismissible: true,
-    color: '#ffffff',
-  };
+  banner: Banner | undefined;
 
-  bannerVisible = true;
+  bannerVisible = false;
 
   dismissBanner() {
     this.bannerVisible = false;
@@ -26,10 +21,10 @@ export class AppBannerComponent implements OnInit {
 
   ngOnInit(): void {
     this.backendService.getAppBanner().subscribe(banner => {
-      if (!banner) {
-        this.bannerVisible = false;
+      if (banner) {
+        this.banner = banner;
+        this.bannerVisible = true;
       }
-      this.banner = banner;
     });
   }
 }


### PR DESCRIPTION
## Description

Bugfix

#### What does this PR do?

On startup, the main page would initialize an empty default banner. When the backend config would come back, saying that there is no banner present, it would disappear. This caused heavy flickering on every reload.
Now the banner is initialized as invisible and only turns visible WHEN / IF the backend config says that there is a banner present.