### PR TITLE
feat: add instance configuration (public availability + consent toggle) with lock page and route guard

### DIFF
--- a/apps/damap-frontend/src/app/app.routes.ts
+++ b/apps/damap-frontend/src/app/app.routes.ts
@@ -19,7 +19,7 @@ export const APP_ROUTES: Routes = [
   },
   {
     path: 'instance-locked',
-    component: InstanceLockedComponent
+    component: InstanceLockedComponent,
   },
   {
     path: '',

--- a/apps/damap-frontend/src/app/app.routes.ts
+++ b/apps/damap-frontend/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { ConsentGuard } from './guard/consent.guard';
 import { environment } from '../environments/environment';
 import { NoTenantComponent } from './components/no-tenant/no-tenant.component';
 import { InstanceLockedComponent } from './components/instance-locked-page/instance-locked.component';
+import { InstanceAvailabilityGuard } from '../../../../libs/damap/src/lib/guards/instance.availability.guard';
 
 export const APP_ROUTES: Routes = [
   {
@@ -14,17 +15,23 @@ export const APP_ROUTES: Routes = [
     canActivate: [AuthGuard],
   },
   {
+    path: 'instance-locked',
+    component: InstanceLockedComponent,
+    canActivate: [AuthGuard],
+  },
+  {
     path: '',
     component: LandingPageComponent,
   },
   {
-    path: 'instance-locked',
-    component: InstanceLockedComponent,
-  },
-  {
     path: '',
     component: LayoutComponent,
-    canActivate: [AuthGuard, TenantGuard, ConsentGuard],
+    canActivate: [
+      AuthGuard,
+      TenantGuard,
+      InstanceAvailabilityGuard,
+      ConsentGuard,
+    ],
     children: [
       {
         path: '',

--- a/apps/damap-frontend/src/app/app.routes.ts
+++ b/apps/damap-frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { AuthGuard, TenantGuard, DamapModule } from '@damap/core';
 import { ConsentGuard } from './guard/consent.guard';
 import { environment } from '../environments/environment';
 import { NoTenantComponent } from './components/no-tenant/no-tenant.component';
+import { InstanceLockedComponent } from './components/instance-locked-page/instance-locked.component';
 
 export const APP_ROUTES: Routes = [
   {
@@ -15,6 +16,10 @@ export const APP_ROUTES: Routes = [
   {
     path: '',
     component: LandingPageComponent,
+  },
+  {
+    path: 'instance-locked',
+    component: InstanceLockedComponent
   },
   {
     path: '',

--- a/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.html
+++ b/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.html
@@ -1,16 +1,16 @@
-<div class="locked-page">
-  <div class="locked-card">
+<div class="page">
+  <div class="content">
     <div class="icon-wrapper">
-      <span class="material-icons">lock</span>
+      <mat-icon>lock</mat-icon>
     </div>
 
     <h1>{{ "instance-lock.title" | translate }}</h1>
 
-    <p class="subtitle">
+    <p class="mat-title-medium subtitle">
       {{ "instance-lock.subtitle" | translate }}
     </p>
 
-    <p class="description">
+    <p class="mat-body-medium description">
       {{ "instance-lock.description" | translate }}
     </p>
   </div>

--- a/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.html
+++ b/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.html
@@ -1,0 +1,17 @@
+<div class="locked-page">
+  <div class="locked-card">
+    <div class="icon-wrapper">
+      <span class="material-icons">lock</span>
+    </div>
+
+    <h1>{{ "instance-lock.title" | translate }}</h1>
+
+    <p class="subtitle">
+      {{ "instance-lock.subtitle" | translate }}
+    </p>
+
+    <p class="description">
+      {{ "instance-lock.description" | translate }}
+    </p>
+  </div>
+</div>

--- a/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.scss
+++ b/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.scss
@@ -1,62 +1,70 @@
-.locked-page {
-  position: fixed;       /* take over entire viewport */
-  inset: 0;              /* top:0 right:0 bottom:0 left:0 */
+.page {
+  height: 100%;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
-
-  overflow: hidden;      /* prevent scrolling inside */
-
-  background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
+  padding: 24px;
+  background: var(--mat-sys-background);
 }
 
-.locked-card {
+.content {
+  max-width: 520px;
   width: 100%;
-  max-width: 560px;
-  background: #ffffff;
-  border-radius: 16px;
-  padding: 3rem 2.5rem;
-  box-shadow:
-    0 8px 24px rgba(15, 23, 42, 0.08),
-    0 2px 8px rgba(15, 23, 42, 0.06);
   text-align: center;
+  padding: 32px 28px;
+  border-radius: 16px;
+
+  /* subtle surface, no harsh white */
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(6px);
+
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
 }
 
 .icon-wrapper {
-  width: 72px;
-  height: 72px;
-  margin: 0 auto 1.5rem;
+  width: 96px;
+  height: 96px;
+  margin: 0 auto 24px auto;
   border-radius: 50%;
-  background: #eef2ff;
+
+  /* neutral container instead of error */
+  background: var(--mat-sys-surface-variant);
+
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.icon-wrapper .material-icons {
-  font-size: 36px;
-  color: #3f51b5;
-}
+.icon-wrapper mat-icon {
+  font-size: 48px;
+  width: 48px;
+  height: 48px;
 
-h1 {
-  margin: 0 0 1rem;
-  font-size: 2rem;
-  font-weight: 700;
-  line-height: 1.2;
-  color: #1e293b;
+  /* neutral icon color */
+  color: var(--mat-sys-primary);
 }
 
 .subtitle {
-  margin: 0 0 1rem;
-  font-size: 1.05rem;
-  line-height: 1.6;
-  color: #334155;
+  margin-bottom: 12px;
 }
 
 .description {
-  margin: 0;
-  font-size: 0.98rem;
-  line-height: 1.6;
-  color: #64748b;
+  color: var(--mat-sys-outline);
+  line-height: 1.5;
+}
+
+h1 {
+  color: var(--mat-sys-on-surface);
+  margin-bottom: 16px;
+}
+
+.subtitle {
+  margin-bottom: 12px;
+  color: var(--mat-sys-on-surface);
+}
+
+.description {
+  color: var(--mat-sys-outline);
+  line-height: 1.5;
 }

--- a/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.scss
+++ b/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.scss
@@ -1,0 +1,62 @@
+.locked-page {
+  position: fixed;       /* take over entire viewport */
+  inset: 0;              /* top:0 right:0 bottom:0 left:0 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+
+  overflow: hidden;      /* prevent scrolling inside */
+
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
+}
+
+.locked-card {
+  width: 100%;
+  max-width: 560px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 3rem 2.5rem;
+  box-shadow:
+    0 8px 24px rgba(15, 23, 42, 0.08),
+    0 2px 8px rgba(15, 23, 42, 0.06);
+  text-align: center;
+}
+
+.icon-wrapper {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 1.5rem;
+  border-radius: 50%;
+  background: #eef2ff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-wrapper .material-icons {
+  font-size: 36px;
+  color: #3f51b5;
+}
+
+h1 {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #1e293b;
+}
+
+.subtitle {
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: #334155;
+}
+
+.description {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.6;
+  color: #64748b;
+}

--- a/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.ts
+++ b/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-instance-locked',
+  templateUrl: './instance-locked.component.html',
+  styleUrls: ['./instance-locked.component.scss'],
+  imports: [
+    TranslateModule
+  ],
+  standalone: true
+})
+export class InstanceLockedComponent {}

--- a/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.ts
+++ b/apps/damap-frontend/src/app/components/instance-locked-page/instance-locked.component.ts
@@ -1,13 +1,19 @@
 import { Component } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-instance-locked',
   templateUrl: './instance-locked.component.html',
   styleUrls: ['./instance-locked.component.scss'],
-  imports: [
-    TranslateModule
-  ],
-  standalone: true
+  imports: [TranslateModule, MatIconModule],
+  standalone: true,
 })
-export class InstanceLockedComponent {}
+export class InstanceLockedComponent {
+  constructor(private translate: TranslateService) {
+    const lang = localStorage.getItem('lang') ?? 'en';
+    if (!this.translate.currentLang) {
+      this.translate.use(lang);
+    }
+  }
+}

--- a/apps/damap-frontend/src/app/guard/consent.guard.ts
+++ b/apps/damap-frontend/src/app/guard/consent.guard.ts
@@ -7,6 +7,7 @@ import {
 import { AuthService, BackendService } from '@damap/core';
 import { ConsentComponent } from '../components/consent/consent.component';
 import { MatDialog } from '@angular/material/dialog';
+import { ConfigService } from '../services/config.service';
 
 @Injectable()
 export class ConsentGuard implements CanActivate {
@@ -17,6 +18,7 @@ export class ConsentGuard implements CanActivate {
     private backendService: BackendService,
     private dialog: MatDialog,
     private authService: AuthService,
+    private configService: ConfigService,
   ) {
     this.consentGiven = true;
   }
@@ -30,12 +32,25 @@ export class ConsentGuard implements CanActivate {
     if (!this.authService.isUserAffiliatedWithATenant()) {
       return true;
     }
+
+    if (
+      !this.authService.isAdmin() &&
+      !this.configService.isPublicAvailable()
+    ) {
+      return true;
+    }
+
     const consentResponse = this.backendService.getConsentGiven();
     consentResponse.subscribe(response => {
       if (response) {
         this.consentGiven = true;
       } else {
         this.consentGiven = false;
+
+        if (!this.configService.isConsentFormEnabled()) {
+          return;
+        }
+
         let dialogRef = this.dialog.open(ConsentComponent, {
           disableClose: true,
         });

--- a/apps/damap-frontend/src/app/services/config.service.spec.ts
+++ b/apps/damap-frontend/src/app/services/config.service.spec.ts
@@ -55,6 +55,7 @@ describe('ConfigService', () => {
       exactColors: true,
       colors: null,
     },
+    publicAvailable: true,
   };
 
   beforeEach(() => {

--- a/apps/damap-frontend/src/app/services/config.service.ts
+++ b/apps/damap-frontend/src/app/services/config.service.ts
@@ -222,4 +222,8 @@ export class ConfigService {
   public isPublicAvailable(): boolean {
     return this.config?.publicAvailable || false;
   }
+
+  public isConsentFormEnabled(): boolean {
+    return this.config?.consentFormEnabled || false;
+  }
 }

--- a/apps/damap-frontend/src/app/services/config.service.ts
+++ b/apps/damap-frontend/src/app/services/config.service.ts
@@ -218,4 +218,8 @@ export class ConfigService {
   public getActiveTemplates(): any[] {
     return this.config?.templates?.filter(t => t.active) || [];
   }
+
+  public isPublicAvailable(): boolean {
+    return this.config?.publicAvailable || false;
+  }
 }

--- a/libs/damap/src/lib/components/admin/admin.component.css
+++ b/libs/damap/src/lib/components/admin/admin.component.css
@@ -12,3 +12,12 @@ div#content {
 .content-max-width {
   max-width: 1440px;
 }
+
+.instance-config-section {
+  margin-top: 12px;
+}
+
+.instance-config-hint {
+  margin-top: 10px;
+  color: #666;
+}

--- a/libs/damap/src/lib/components/admin/admin.component.html
+++ b/libs/damap/src/lib/components/admin/admin.component.html
@@ -130,4 +130,23 @@
     <mat-icon>edit</mat-icon>
     {{ "admin.edit.templates" | translate }}
   </button>
+  <hr />
+  <h2 translate>admin.instance-config</h2>
+
+  <div class="instance-config-section">
+    <mat-slide-toggle
+      [checked]="instanceConfig?.publicAvailable"
+      (change)="onPublicAvailabilityToggle($event.checked)">
+      {{ "admin.instance-config.public-available" | translate }}
+    </mat-slide-toggle>
+
+    <p class="instance-config-hint">
+      {{
+        (instanceConfig?.publicAvailable
+            ? "admin.instance-config.public-available-enabled"
+            : "admin.instance-config.public-available-disabled"
+        ) | translate
+      }}
+    </p>
+  </div>
 </div>

--- a/libs/damap/src/lib/components/admin/admin.component.html
+++ b/libs/damap/src/lib/components/admin/admin.component.html
@@ -131,7 +131,7 @@
     {{ "admin.edit.templates" | translate }}
   </button>
   <hr />
-  <h2 translate>admin.instance-config</h2>
+  <h2 translate>admin.instance-config.title</h2>
 
   <div class="instance-config-section">
     <mat-slide-toggle
@@ -143,8 +143,23 @@
     <p class="instance-config-hint">
       {{
         (instanceConfig?.publicAvailable
-            ? "admin.instance-config.public-available-enabled"
-            : "admin.instance-config.public-available-disabled"
+          ? "admin.instance-config.public-available-enabled"
+          : "admin.instance-config.public-available-disabled"
+        ) | translate
+      }}
+    </p>
+
+    <mat-slide-toggle
+      [checked]="instanceConfig?.consentFormEnabled"
+      (change)="onConsentFormEnabledToggle($event.checked)">
+      {{ "admin.instance-config.consent-form-enabled" | translate }}
+    </mat-slide-toggle>
+
+    <p class="instance-config-hint">
+      {{
+        (instanceConfig?.consentFormEnabled
+          ? "admin.instance-config.consent-form-enabled-on"
+          : "admin.instance-config.consent-form-enabled-off"
         ) | translate
       }}
     </p>

--- a/libs/damap/src/lib/components/admin/admin.component.ts
+++ b/libs/damap/src/lib/components/admin/admin.component.ts
@@ -16,6 +16,7 @@ import { BannerDialogComponent } from './banner-dialog/banner-dialog.component';
 import { DeleteStorageWarningDialogComponent } from '../../widgets/internal-storage-table/dialog/delete-storage-warning-dialog.component';
 import { DeleteBannerWarningDialogComponent } from './banner-dialog/delete-banner-warning-dialog.component';
 import validator from 'validator';
+import { InstanceConfig } from '../../domain/instance-config';
 
 @Component({
   selector: 'damap-admin',
@@ -37,6 +38,8 @@ export class AdminComponent implements OnInit {
   selectedInternalStorageId: number;
   selectedInternalStorageUrl: string;
 
+  instanceConfig: InstanceConfig | null = null;
+
   appBanner: Banner | null = null;
 
   ngOnInit(): void {
@@ -49,6 +52,19 @@ export class AdminComponent implements OnInit {
 
     this.backendService.getAppBanner().subscribe(banner => {
       this.appBanner = banner;
+    });
+
+    this.backendService.getInstanceConfig().subscribe({
+      next: config => {
+        this.instanceConfig = config;
+      },
+      error: error => {
+        if (error.error?.message) {
+          this.feedbackService.error(error.error.message);
+        } else {
+          this.feedbackService.error(error.message);
+        }
+      },
     });
   }
 
@@ -240,5 +256,33 @@ export class AdminComponent implements OnInit {
 
   navigateTo(path: string) {
     this.router.navigate([path]);
+  }
+
+  onPublicAvailabilityToggle(publicAvailable: boolean) {
+    const updatedConfig: InstanceConfig = {
+      publicAvailable,
+    };
+
+    this.backendService.updateInstanceConfig(updatedConfig).subscribe({
+      next: config => {
+        this.instanceConfig = config;
+        this.feedbackService.success('http.success.instance-config.update');
+      },
+      error: error => {
+        if (error.error?.message) {
+          this.feedbackService.error(error.error.message);
+        } else {
+          this.feedbackService.error(error.message);
+        }
+
+        // revert UI state if save failed
+        if (this.instanceConfig) {
+          this.instanceConfig = {
+            ...this.instanceConfig,
+            publicAvailable: !publicAvailable,
+          };
+        }
+      },
+    });
   }
 }

--- a/libs/damap/src/lib/components/admin/admin.component.ts
+++ b/libs/damap/src/lib/components/admin/admin.component.ts
@@ -259,7 +259,12 @@ export class AdminComponent implements OnInit {
   }
 
   onPublicAvailabilityToggle(publicAvailable: boolean) {
+    if (!this.instanceConfig) {
+      return;
+    }
+
     const updatedConfig: InstanceConfig = {
+      ...this.instanceConfig,
       publicAvailable,
     };
 
@@ -275,13 +280,40 @@ export class AdminComponent implements OnInit {
           this.feedbackService.error(error.message);
         }
 
-        // revert UI state if save failed
-        if (this.instanceConfig) {
-          this.instanceConfig = {
-            ...this.instanceConfig,
-            publicAvailable: !publicAvailable,
-          };
+        this.instanceConfig = {
+          ...this.instanceConfig!,
+          publicAvailable: !publicAvailable,
+        };
+      },
+    });
+  }
+
+  onConsentFormEnabledToggle(consentFormEnabled: boolean) {
+    if (!this.instanceConfig) {
+      return;
+    }
+
+    const updatedConfig: InstanceConfig = {
+      ...this.instanceConfig,
+      consentFormEnabled,
+    };
+
+    this.backendService.updateInstanceConfig(updatedConfig).subscribe({
+      next: config => {
+        this.instanceConfig = config;
+        this.feedbackService.success('http.success.instance-config.update');
+      },
+      error: error => {
+        if (error.error?.message) {
+          this.feedbackService.error(error.error.message);
+        } else {
+          this.feedbackService.error(error.message);
         }
+
+        this.instanceConfig = {
+          ...this.instanceConfig!,
+          consentFormEnabled: !consentFormEnabled,
+        };
       },
     });
   }

--- a/libs/damap/src/lib/components/admin/admin.module.ts
+++ b/libs/damap/src/lib/components/admin/admin.module.ts
@@ -70,7 +70,7 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
     MatProgressSpinnerModule,
     DragDropModule,
     MatTooltipModule,
-    MatSlideToggle
+    MatSlideToggle,
   ],
   declarations: [
     AdminComponent,

--- a/libs/damap/src/lib/components/admin/admin.module.ts
+++ b/libs/damap/src/lib/components/admin/admin.module.ts
@@ -36,6 +36,7 @@ import { RouterModule } from '@angular/router';
 import { SharedModule } from '../../shared/shared.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationManagementComponent } from './translation-management/translation-management.component';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
 
 @NgModule({
   imports: [
@@ -69,6 +70,7 @@ import { TranslationManagementComponent } from './translation-management/transla
     MatProgressSpinnerModule,
     DragDropModule,
     MatTooltipModule,
+    MatSlideToggle
   ],
   declarations: [
     AdminComponent,

--- a/libs/damap/src/lib/damap.module.ts
+++ b/libs/damap/src/lib/damap.module.ts
@@ -20,18 +20,15 @@ import { PlansComponent } from './components/plans/plans.component';
 import { PlansModule } from './components/plans/plans.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { EditTemplatesPageComponent } from './components/admin/edit-templates-page/edit-templates-page.component';
-import { InstanceAvailabilityGuard } from './guards/instance.availability.guard';
 
 export const DAMAP_ROUTES: Route[] = [
   {
     path: 'dashboard',
     component: DashboardComponent,
-    canActivate: [InstanceAvailabilityGuard],
   },
   {
     path: 'plans',
     component: PlansComponent,
-    canActivate: [InstanceAvailabilityGuard],
   },
   {
     path: 'info',
@@ -39,25 +36,21 @@ export const DAMAP_ROUTES: Route[] = [
       {
         path: 'damap',
         component: DamapInfoComponent,
-        canActivate: [InstanceAvailabilityGuard],
       },
       {
         path: 'how-to-create',
         component: DmpInstructionsComponent,
-        canActivate: [InstanceAvailabilityGuard],
       },
     ],
   },
   {
     path: 'dmp',
-    canActivate: [InstanceAvailabilityGuard],
     loadChildren: () =>
       import('./components/dmp/dmp.module').then(m => m.DmpModule),
   },
   {
     path: 'gdpr',
     component: GdprComponent,
-    canActivate: [InstanceAvailabilityGuard],
   },
   { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] },
   {

--- a/libs/damap/src/lib/damap.module.ts
+++ b/libs/damap/src/lib/damap.module.ts
@@ -23,13 +23,29 @@ import { EditTemplatesPageComponent } from './components/admin/edit-templates-pa
 import { InstanceAvailabilityGuard } from './guards/instance.availability.guard';
 
 export const DAMAP_ROUTES: Route[] = [
-  { path: 'dashboard', component: DashboardComponent, canActivate: [InstanceAvailabilityGuard] },
-  { path: 'plans', component: PlansComponent, canActivate: [InstanceAvailabilityGuard] },
+  {
+    path: 'dashboard',
+    component: DashboardComponent,
+    canActivate: [InstanceAvailabilityGuard],
+  },
+  {
+    path: 'plans',
+    component: PlansComponent,
+    canActivate: [InstanceAvailabilityGuard],
+  },
   {
     path: 'info',
     children: [
-      { path: 'damap', component: DamapInfoComponent, canActivate: [InstanceAvailabilityGuard] },
-      { path: 'how-to-create', component: DmpInstructionsComponent, canActivate: [InstanceAvailabilityGuard] },
+      {
+        path: 'damap',
+        component: DamapInfoComponent,
+        canActivate: [InstanceAvailabilityGuard],
+      },
+      {
+        path: 'how-to-create',
+        component: DmpInstructionsComponent,
+        canActivate: [InstanceAvailabilityGuard],
+      },
     ],
   },
   {
@@ -38,7 +54,11 @@ export const DAMAP_ROUTES: Route[] = [
     loadChildren: () =>
       import('./components/dmp/dmp.module').then(m => m.DmpModule),
   },
-  { path: 'gdpr', component: GdprComponent, canActivate: [InstanceAvailabilityGuard] },
+  {
+    path: 'gdpr',
+    component: GdprComponent,
+    canActivate: [InstanceAvailabilityGuard],
+  },
   { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] },
   {
     path: 'admin/theme',

--- a/libs/damap/src/lib/damap.module.ts
+++ b/libs/damap/src/lib/damap.module.ts
@@ -20,23 +20,25 @@ import { PlansComponent } from './components/plans/plans.component';
 import { PlansModule } from './components/plans/plans.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { EditTemplatesPageComponent } from './components/admin/edit-templates-page/edit-templates-page.component';
+import { InstanceAvailabilityGuard } from './guards/instance.availability.guard';
 
 export const DAMAP_ROUTES: Route[] = [
-  { path: 'dashboard', component: DashboardComponent },
-  { path: 'plans', component: PlansComponent },
+  { path: 'dashboard', component: DashboardComponent, canActivate: [InstanceAvailabilityGuard] },
+  { path: 'plans', component: PlansComponent, canActivate: [InstanceAvailabilityGuard] },
   {
     path: 'info',
     children: [
-      { path: 'damap', component: DamapInfoComponent },
-      { path: 'how-to-create', component: DmpInstructionsComponent },
+      { path: 'damap', component: DamapInfoComponent, canActivate: [InstanceAvailabilityGuard] },
+      { path: 'how-to-create', component: DmpInstructionsComponent, canActivate: [InstanceAvailabilityGuard] },
     ],
   },
   {
     path: 'dmp',
+    canActivate: [InstanceAvailabilityGuard],
     loadChildren: () =>
       import('./components/dmp/dmp.module').then(m => m.DmpModule),
   },
-  { path: 'gdpr', component: GdprComponent },
+  { path: 'gdpr', component: GdprComponent, canActivate: [InstanceAvailabilityGuard] },
   { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] },
   {
     path: 'admin/theme',

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -26,4 +26,5 @@ export interface Config {
   readonly multitenancyEnabled: boolean;
   readonly tenants: string[];
   readonly templates: any[];
+  readonly publicAvailable: boolean;
 }

--- a/libs/damap/src/lib/domain/config.ts
+++ b/libs/damap/src/lib/domain/config.ts
@@ -27,4 +27,5 @@ export interface Config {
   readonly tenants: string[];
   readonly templates: any[];
   readonly publicAvailable: boolean;
+  readonly consentFormEnabled: boolean;
 }

--- a/libs/damap/src/lib/domain/instance-config.ts
+++ b/libs/damap/src/lib/domain/instance-config.ts
@@ -1,0 +1,3 @@
+export interface InstanceConfig {
+  publicAvailable: boolean;
+}

--- a/libs/damap/src/lib/domain/instance-config.ts
+++ b/libs/damap/src/lib/domain/instance-config.ts
@@ -1,3 +1,4 @@
 export interface InstanceConfig {
   publicAvailable: boolean;
+  consentFormEnabled: boolean;
 }

--- a/libs/damap/src/lib/guards/instance.availability.guard.ts
+++ b/libs/damap/src/lib/guards/instance.availability.guard.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
-  CanActivate, Router,
-  RouterStateSnapshot
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
 } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { AuthService } from '../auth/auth.service';
@@ -13,7 +14,7 @@ export class InstanceAvailabilityGuard implements CanActivate {
   constructor(
     private authService: AuthService,
     private configService: ConfigService,
-    private router: Router
+    private router: Router,
   ) {}
 
   canActivate(

--- a/libs/damap/src/lib/guards/instance.availability.guard.ts
+++ b/libs/damap/src/lib/guards/instance.availability.guard.ts
@@ -1,11 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  Router,
-  RouterStateSnapshot,
-} from '@angular/router';
-import { Observable, of } from 'rxjs';
+import { CanActivate, Router, UrlTree } from '@angular/router';
 import { AuthService } from '../auth/auth.service';
 import { ConfigService } from '../../../../../apps/damap-frontend/src/app/services/config.service';
 
@@ -17,23 +11,16 @@ export class InstanceAvailabilityGuard implements CanActivate {
     private router: Router,
   ) {}
 
-  canActivate(
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot,
-  ): Observable<boolean> {
-    if (this.authService.isAdmin()) {
-      return of(true);
+  canActivate(): boolean | UrlTree {
+    if (this.authService.isAdmin() || this.configService.isPublicAvailable()) {
+      return true;
     }
 
-    var publicAvailable = this.configService.isPublicAvailable();
-    console.log('Public availability:', publicAvailable);
-    if (publicAvailable) {
-      return of(true);
+    // tenant guard will take over
+    if (!this.authService.isUserAffiliatedWithATenant()) {
+      return true;
     }
 
-    // navigate to the instance locked page
-
-    this.router.navigate(['/instance-locked']);
-    return of(false);
+    return this.router.createUrlTree(['/instance-locked']);
   }
 }

--- a/libs/damap/src/lib/guards/instance.availability.guard.ts
+++ b/libs/damap/src/lib/guards/instance.availability.guard.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate, Router,
+  RouterStateSnapshot
+} from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { AuthService } from '../auth/auth.service';
+import { ConfigService } from '../../../../../apps/damap-frontend/src/app/services/config.service';
+
+@Injectable({ providedIn: 'root' })
+export class InstanceAvailabilityGuard implements CanActivate {
+  constructor(
+    private authService: AuthService,
+    private configService: ConfigService,
+    private router: Router
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot,
+  ): Observable<boolean> {
+    if (this.authService.isAdmin()) {
+      return of(true);
+    }
+
+    var publicAvailable = this.configService.isPublicAvailable();
+    console.log('Public availability:', publicAvailable);
+    if (publicAvailable) {
+      return of(true);
+    }
+
+    // navigate to the instance locked page
+
+    this.router.navigate(['/instance-locked']);
+    return of(false);
+  }
+}

--- a/libs/damap/src/lib/services/backend.service.ts
+++ b/libs/damap/src/lib/services/backend.service.ts
@@ -33,6 +33,7 @@ import { RepositoryDetails } from '../domain/repository-details';
 import { SearchResult } from '../domain/search/search-result';
 import { TranslateService } from '@ngx-translate/core';
 import { Version } from '../domain/version';
+import { InstanceConfig } from '../domain/instance-config';
 
 @Injectable({
   providedIn: 'root',
@@ -618,6 +619,36 @@ export class BackendService {
 
   deleteExportTemplate(id: number): Observable<any> {
     return this.http.delete(`${this.backendUrl}admin/export-templates/${id}`);
+  }
+
+  getInstanceConfig(): Observable<InstanceConfig> {
+    return this.http
+      .get<InstanceConfig>(`${this.backendUrl}admin/instance-config`)
+      .pipe(
+        retry(3),
+        catchError(this.handleError('http.error.admin.instance-config.load')),
+      );
+  }
+
+  updateInstanceConfig(
+    instanceConfig: InstanceConfig,
+  ): Observable<InstanceConfig> {
+    const httpOptions = {
+      headers: new HttpHeaders({
+        'Content-Type': 'application/json',
+      }),
+    };
+
+    return this.http
+      .put<InstanceConfig>(
+        `${this.backendUrl}admin/instance-config`,
+        instanceConfig,
+        httpOptions,
+      )
+      .pipe(
+        retry(3),
+        catchError(this.handleError('http.error.admin.instance-config.update')),
+      );
   }
 
   private handleError(message = 'http.error.standard') {


### PR DESCRIPTION
## Description

Feature

#### What does this PR do?

Adds frontend support for instance-level configuration.

This PR introduces:
- an instance locked page for non-admin users
- route guarding based on the `publicAvailable` config flag
- admin toggles for public availability and consent form visibility

When an instance is not public, non-admin users are redirected to the locked page. Admin users can still access the application and manage the instance configuration.

#### Dependencies

Requires backend support for instance config:
- `GET /api/admin/instance-config`
- `PUT /api/admin/instance-config`
- config response including `publicAvailable` and `consentFormEnabled`
