### PR TITLE
Display only custom values when a deactivated language is active.

### DIFF
--- a/libs/damap/src/lib/components/admin/translation-management/translation-management.component.ts
+++ b/libs/damap/src/lib/components/admin/translation-management/translation-management.component.ts
@@ -23,6 +23,9 @@ import { TranslationLoaderService } from '@damap/core';
   standalone: false,
 })
 export class TranslationManagementComponent implements OnInit {
+  private static readonly FILTER_KEY = 'damap.translation.filters';
+  private restoredPageIndex: number | null = null;
+
   pageSize = 5;
   pageIndex = 0;
 
@@ -56,6 +59,18 @@ export class TranslationManagementComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    const savedFilters = sessionStorage.getItem(
+      TranslationManagementComponent.FILTER_KEY,
+    );
+    if (savedFilters) {
+      const { search, section, status, pageIndex } = JSON.parse(savedFilters);
+      this.searchControl.setValue(search ?? '', { emitEvent: false });
+      this.sectionFilter = section ?? 'all';
+      this.statusFilterControl.setValue(status ?? 'all', { emitEvent: false });
+      this.restoredPageIndex = pageIndex ?? 0;
+      sessionStorage.removeItem(TranslationManagementComponent.FILTER_KEY);
+    }
+
     this.searchControl.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged())
       .subscribe(() => {
@@ -310,6 +325,16 @@ export class TranslationManagementComponent implements OnInit {
           this.originalCustomValue = updated.value ?? '';
           this.translate.reloadLang(this.selectedLanguage).subscribe(() => {
             this.feedbackService.success('http.success.translations.update');
+            sessionStorage.setItem(
+              TranslationManagementComponent.FILTER_KEY,
+              JSON.stringify({
+                search: this.searchControl.value ?? '',
+                section: this.sectionFilter,
+                status: this.statusFilterControl.value ?? 'all',
+                pageIndex: this.pageIndex,
+              }),
+            );
+            window.location.reload();
           });
         },
         error: err => {
@@ -424,7 +449,8 @@ export class TranslationManagementComponent implements OnInit {
     this.filteredTranslations = items;
 
     if (resetPage) {
-      this.pageIndex = 0;
+      this.pageIndex = this.restoredPageIndex ?? 0;
+      this.restoredPageIndex = null;
     } else if (this.pageIndex > this.totalPages - 1) {
       this.pageIndex = Math.max(0, this.totalPages - 1);
     }

--- a/libs/damap/src/lib/services/backend-translate-loader.ts
+++ b/libs/damap/src/lib/services/backend-translate-loader.ts
@@ -22,8 +22,9 @@ export class BackendTranslateLoader implements TranslateLoader {
   private entriesToNested(entries: TranslationEntry[]): Record<string, any> {
     const result: Record<string, any> = {};
     for (const entry of entries) {
-      if (!entry.active) continue;
-      const value = entry.value || entry.defaultValue;
+      const value = entry.active
+        ? entry.value || entry.defaultValue
+        : entry.value; // inactive language: only show custom value; missing value falls back to raw key
       if (!value) continue;
       this.setNestedValue(result, entry.translationKey, value);
     }


### PR DESCRIPTION
Persist filters between updates in admin dashboard. Show custom values when inactive language is selected.
