### PR TITLE
Show custom values on deactivated lanuguages. Persist filters between reloads.

### DIFF
--- a/libs/damap/src/lib/components/admin/translation-management/translation-management.component.ts
+++ b/libs/damap/src/lib/components/admin/translation-management/translation-management.component.ts
@@ -23,9 +23,6 @@ import { TranslationLoaderService } from '@damap/core';
   standalone: false,
 })
 export class TranslationManagementComponent implements OnInit {
-  private static readonly FILTER_KEY = 'damap.translation.filters';
-  private restoredPageIndex: number | null = null;
-
   pageSize = 5;
   pageIndex = 0;
 
@@ -59,18 +56,6 @@ export class TranslationManagementComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const savedFilters = sessionStorage.getItem(
-      TranslationManagementComponent.FILTER_KEY,
-    );
-    if (savedFilters) {
-      const { search, section, status, pageIndex } = JSON.parse(savedFilters);
-      this.searchControl.setValue(search ?? '', { emitEvent: false });
-      this.sectionFilter = section ?? 'all';
-      this.statusFilterControl.setValue(status ?? 'all', { emitEvent: false });
-      this.restoredPageIndex = pageIndex ?? 0;
-      sessionStorage.removeItem(TranslationManagementComponent.FILTER_KEY);
-    }
-
     this.searchControl.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged())
       .subscribe(() => {
@@ -325,16 +310,6 @@ export class TranslationManagementComponent implements OnInit {
           this.originalCustomValue = updated.custom ?? '';
           this.translate.reloadLang(this.selectedLanguage).subscribe(() => {
             this.feedbackService.success('http.success.translations.update');
-            sessionStorage.setItem(
-              TranslationManagementComponent.FILTER_KEY,
-              JSON.stringify({
-                search: this.searchControl.value ?? '',
-                section: this.sectionFilter,
-                status: this.statusFilterControl.value ?? 'all',
-                pageIndex: this.pageIndex,
-              }),
-            );
-            window.location.reload();
           });
         },
         error: err => {
@@ -449,8 +424,7 @@ export class TranslationManagementComponent implements OnInit {
     this.filteredTranslations = items;
 
     if (resetPage) {
-      this.pageIndex = this.restoredPageIndex ?? 0;
-      this.restoredPageIndex = null;
+      this.pageIndex = 0;
     } else if (this.pageIndex > this.totalPages - 1) {
       this.pageIndex = Math.max(0, this.totalPages - 1);
     }

--- a/libs/damap/src/lib/components/admin/translation-management/translation-management.component.ts
+++ b/libs/damap/src/lib/components/admin/translation-management/translation-management.component.ts
@@ -23,6 +23,9 @@ import { TranslationLoaderService } from '@damap/core';
   standalone: false,
 })
 export class TranslationManagementComponent implements OnInit {
+  private static readonly FILTER_KEY = 'damap.translation.filters';
+  private restoredPageIndex: number | null = null;
+
   pageSize = 5;
   pageIndex = 0;
 
@@ -56,6 +59,18 @@ export class TranslationManagementComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    const savedFilters = sessionStorage.getItem(
+      TranslationManagementComponent.FILTER_KEY,
+    );
+    if (savedFilters) {
+      const { search, section, status, pageIndex } = JSON.parse(savedFilters);
+      this.searchControl.setValue(search ?? '', { emitEvent: false });
+      this.sectionFilter = section ?? 'all';
+      this.statusFilterControl.setValue(status ?? 'all', { emitEvent: false });
+      this.restoredPageIndex = pageIndex ?? 0;
+      sessionStorage.removeItem(TranslationManagementComponent.FILTER_KEY);
+    }
+
     this.searchControl.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged())
       .subscribe(() => {
@@ -310,6 +325,16 @@ export class TranslationManagementComponent implements OnInit {
           this.originalCustomValue = updated.custom ?? '';
           this.translate.reloadLang(this.selectedLanguage).subscribe(() => {
             this.feedbackService.success('http.success.translations.update');
+            sessionStorage.setItem(
+              TranslationManagementComponent.FILTER_KEY,
+              JSON.stringify({
+                search: this.searchControl.value ?? '',
+                section: this.sectionFilter,
+                status: this.statusFilterControl.value ?? 'all',
+                pageIndex: this.pageIndex,
+              }),
+            );
+            window.location.reload();
           });
         },
         error: err => {
@@ -424,7 +449,8 @@ export class TranslationManagementComponent implements OnInit {
     this.filteredTranslations = items;
 
     if (resetPage) {
-      this.pageIndex = 0;
+      this.pageIndex = this.restoredPageIndex ?? 0;
+      this.restoredPageIndex = null;
     } else if (this.pageIndex > this.totalPages - 1) {
       this.pageIndex = Math.max(0, this.totalPages - 1);
     }

--- a/libs/damap/src/lib/services/backend-translate-loader.ts
+++ b/libs/damap/src/lib/services/backend-translate-loader.ts
@@ -22,9 +22,8 @@ export class BackendTranslateLoader implements TranslateLoader {
   private entriesToNested(entries: TranslationEntry[]): Record<string, any> {
     const result: Record<string, any> = {};
     for (const entry of entries) {
-      const custom = entry.active
-        ? entry.custom || entry.defaultValue
-        : entry.custom;
+      if (!entry.active) continue;
+      const custom = entry.custom || entry.defaultValue;
       if (!custom) continue;
       this.setNestedValue(result, entry.translationKey, custom);
     }

--- a/libs/damap/src/lib/services/backend-translate-loader.ts
+++ b/libs/damap/src/lib/services/backend-translate-loader.ts
@@ -22,8 +22,9 @@ export class BackendTranslateLoader implements TranslateLoader {
   private entriesToNested(entries: TranslationEntry[]): Record<string, any> {
     const result: Record<string, any> = {};
     for (const entry of entries) {
-      if (!entry.active) continue;
-      const custom = entry.custom || entry.defaultValue;
+      const custom = entry.active
+        ? entry.custom || entry.defaultValue
+        : entry.custom;
       if (!custom) continue;
       this.setNestedValue(result, entry.translationKey, custom);
     }


### PR DESCRIPTION
Show custom values while on a deactivated language.
Persist filters between admin translations dashboard reloads.
