### PR TITLE
bugfix: select correct language when browser language is not available in application translations

### DIFF
--- a/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
+++ b/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
@@ -49,9 +49,9 @@ export class LandingPageComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    // TODO: The fallback doesnt work when english has been deactivated
     const preferredLang =
       localStorage.getItem('lang') || this.translate.getBrowserLang() || 'en';
-
     this.translate.getTranslation(preferredLang).subscribe(translations => {
       const languageToUse =
         translations && Object.keys(translations).length > 0

--- a/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
+++ b/apps/damap-frontend/src/app/components/landing-page/landing-page.component.ts
@@ -49,8 +49,19 @@ export class LandingPageComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    const browserLang = this.translate.getBrowserLang();
-    this.translate.use(browserLang?.match(/en|de/) ? browserLang : 'en');
+    const preferredLang =
+      localStorage.getItem('lang') || this.translate.getBrowserLang() || 'en';
+
+    this.translate.getTranslation(preferredLang).subscribe(translations => {
+      const languageToUse =
+        translations && Object.keys(translations).length > 0
+          ? preferredLang
+          : 'en';
+
+      this.translate.use(languageToUse);
+      localStorage.setItem('lang', languageToUse);
+    });
+
     this.backendDown$ = this.configService.isBackendDown();
   }
 }


### PR DESCRIPTION
## Description

Bugfix

#### What does this PR do?

This PR fixes language initialization on the landing page.

Previously, the frontend selected either the browser language or English based only on a hardcoded `en|de` check. This could still select a language for which no backend translations exist, resulting in empty translations being loaded.

Now the frontend first checks whether translations exist for the preferred language from `localStorage` or the browser. If no translations are returned, it falls back to English and stores the resolved language in `localStorage`.
