### PR TITLE
Info Section: Fix wrong translation key

### DIFF
--- a/libs/damap/src/lib/components/damap-info/damap-info.component.html
+++ b/libs/damap/src/lib/components/damap-info/damap-info.component.html
@@ -35,7 +35,7 @@
               info.about.bulletpoints.supports
             </li>
             <li class="mat-list-item" translate>
-              dashboard.tool.bulletpoints.benefits.text
+              info.about.bulletpoints.benefits.text
               <ul class="mat-sublist">
                 <li class="mat-list-item" translate>
                   info.about.bulletpoints.benefits.one


### PR DESCRIPTION
One key still had the old structure, easy fix by adapting to new one (key already exists in backend)
