### PR TITLE
Add and rename translation keys

### DIFF
--- a/libs/damap/src/lib/components/admin/translation-management/translation-management.component.html
+++ b/libs/damap/src/lib/components/admin/translation-management/translation-management.component.html
@@ -1,7 +1,7 @@
 <div class="translation-management">
   <div class="header">
     <div>
-      <h2>Languages</h2>
+      <h2>{{ "admin.appTranslations.boldTitle" | translate }}</h2>
       <p class="subtitle">Manage available languages and their translations.</p>
     </div>
     <div class="language-actions">

--- a/libs/damap/src/lib/services/summary.service.ts
+++ b/libs/damap/src/lib/services/summary.service.ts
@@ -123,7 +123,7 @@ export class SummaryService {
       if (dmp[kind] === DataKind.NONE) {
         datasetLevel.completeness += 50;
         datasetLevel.status.push(
-          `dmp.steps.summary.data.specify.datasets.none.${datakind}`,
+          `dmp.steps.summary.specifyData.datasets.none.${datakind}`,
         );
       } else if (dmp[kind] === DataKind.SPECIFY) {
         // check if datasets exist
@@ -134,12 +134,12 @@ export class SummaryService {
           datasetLevel.completeness += 50;
         }
         datasetLevel.status.push(
-          `dmp.steps.summary.data.specify.datasets.${datakind}`,
+          `dmp.steps.summary.specifyData.datasets.${datakind}`,
         );
         datasetLevel.status.push(`${datasets.length}. `);
       } else if (dmp[kind] === DataKind.UNKNOWN) {
         datasetLevel.status.push(
-          `dmp.steps.summary.data.specify.datasets.unknown.${datakind}`,
+          `dmp.steps.summary.specifyData.datasets.unknown.${datakind}`,
         );
       }
     }
@@ -152,7 +152,7 @@ export class SummaryService {
       if (!dmp.noDataExplanation) {
         datasetLevel.completeness -= 50;
         datasetLevel.status.push(
-          'dmp.steps.summary.data.specify.datasets.missingexplanation',
+          'dmp.steps.summary.specifyData.missingExplanation',
         );
       }
     } else if (
@@ -164,12 +164,12 @@ export class SummaryService {
           datasetLevel.completeness >= 20
             ? datasetLevel.completeness - 20
             : datasetLevel.completeness;
-        datasetLevel.status.push(
-          'dmp.steps.summary.data.specify.datasets.datageneration',
-        );
+        datasetLevel.status.push('dmp.steps.summary.specifyData.missingSource');
       }
     } else if (!dmp.dataKind && !dmp.reusedDataKind) {
-      datasetLevel.status.push('dmp.steps.summary.data.specify.none.none');
+      datasetLevel.status.push(
+        'dmp.steps.summary.specifyData.newData.unspecified',
+      );
     }
 
     return datasetLevel;

--- a/libs/damap/src/lib/services/summary.service.ts
+++ b/libs/damap/src/lib/services/summary.service.ts
@@ -123,7 +123,7 @@ export class SummaryService {
       if (dmp[kind] === DataKind.NONE) {
         datasetLevel.completeness += 50;
         datasetLevel.status.push(
-          `dmp.steps.summary.specifyData.datasets.none.${datakind}`,
+          `dmp.steps.summary.data.specify.datasets.none.${datakind}`,
         );
       } else if (dmp[kind] === DataKind.SPECIFY) {
         // check if datasets exist
@@ -134,12 +134,12 @@ export class SummaryService {
           datasetLevel.completeness += 50;
         }
         datasetLevel.status.push(
-          `dmp.steps.summary.specifyData.datasets.${datakind}`,
+          `dmp.steps.summary.data.specify.datasets.${datakind}`,
         );
         datasetLevel.status.push(`${datasets.length}. `);
       } else if (dmp[kind] === DataKind.UNKNOWN) {
         datasetLevel.status.push(
-          `dmp.steps.summary.specifyData.datasets.unknown.${datakind}`,
+          `dmp.steps.summary.data.specify.datasets.unknown.${datakind}`,
         );
       }
     }
@@ -152,7 +152,7 @@ export class SummaryService {
       if (!dmp.noDataExplanation) {
         datasetLevel.completeness -= 50;
         datasetLevel.status.push(
-          'dmp.steps.summary.specifyData.missingExplanation',
+          'dmp.steps.summary.data.specify.datasets.missingexplanation',
         );
       }
     } else if (
@@ -164,11 +164,13 @@ export class SummaryService {
           datasetLevel.completeness >= 20
             ? datasetLevel.completeness - 20
             : datasetLevel.completeness;
-        datasetLevel.status.push('dmp.steps.summary.specifyData.missingSource');
+        datasetLevel.status.push(
+          'dmp.steps.summary.data.specify.datasets.datageneration',
+        );
       }
     } else if (!dmp.dataKind && !dmp.reusedDataKind) {
       datasetLevel.status.push(
-        'dmp.steps.summary.specifyData.newData.unspecified',
+        'dmp.steps.summary.data.specify.datasets.unspecified',
       );
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix

#### What does this PR do?
- Added a translation key for the text in bold in the admin appTranslations component instead of hardcoding `"Languages"` in the html.
- Renamed a translation key in summary from `dmp.steps.summary.data.specify.datasets.none.none` to `dmp.steps.summary.data.specify.datasets.unspecified`.

Backend PR: GH-https://github.com/damap-org/damap-backend/pull/526

*Edited to reflect new changes
